### PR TITLE
feat: add Professional Edition docs to wiki

### DIFF
--- a/wiki/docs/pe/dashboard.md
+++ b/wiki/docs/pe/dashboard.md
@@ -1,0 +1,74 @@
+# PE Dashboard
+
+HomelabARR PE includes a full web dashboard built with React 19, TypeScript, and shadcn/ui. It provides real-time container management, storage monitoring, and one-click app deployment.
+
+## Accessing the Dashboard
+
+After starting HomelabARR PE, open your browser to:
+
+```
+http://your-server-ip:8080
+```
+
+Default credentials are set during first run.
+
+## Dashboard Sections
+
+### Container Management
+
+The main dashboard shows all running containers with:
+
+- **Status** — Running, stopped, unhealthy, with color-coded indicators
+- **Resource usage** — CPU and memory per container
+- **Quick actions** — Start, stop, restart, view logs, open web UI
+- **Bulk operations** — Select multiple containers for batch actions
+- **Real-time updates** — WebSocket pushes status changes instantly
+
+### App Store
+
+Browse and deploy 137+ pre-configured applications:
+
+- **Categories** — Media servers, download clients, monitoring, security, backup, productivity, and more
+- **One-click install** — Select an app, configure ports and volumes, deploy
+- **Search** — Filter by name, category, or description
+- **Status indicators** — See which apps are already installed
+
+### Storage Dashboard
+
+Visual overview of your storage infrastructure:
+
+- **Pool capacity** — Total, used, and available across all drives
+- **Drive health** — SMART data, temperature, I/O rates per drive
+- **Cache status** — NVMe utilization, files pending age-out
+- **SnapRAID status** — Last sync, scrub results, parity health
+- **MergerFS pool** — Per-drive breakdown within the unified pool
+
+### System Monitoring
+
+Hardware and system metrics:
+
+- **CPU** — Usage, temperature, load average
+- **Memory** — Used, cached, available
+- **Network** — Throughput per interface
+- **Disk I/O** — Read/write speeds per drive
+
+### Settings
+
+Configuration management through the UI:
+
+- **Storage config** — Add drives, configure cache mover rules, SnapRAID schedule
+- **Network** — Traefik reverse proxy, domain configuration
+- **Security** — Authelia integration, user management
+- **Backup** — Scheduled backup configuration
+- **Updates** — Check for new PE versions
+
+## Tech Stack
+
+- **React 19** with TypeScript
+- **shadcn/ui** component library (51 components)
+- **Tailwind CSS** for styling
+- **WebSocket** for real-time updates (30-second cache TTL)
+- **Vite** build system
+- **Dark mode** with system preference detection
+
+The frontend is embedded in the Go binary via `go:embed` — no separate web server needed.

--- a/wiki/docs/pe/file-sharing.md
+++ b/wiki/docs/pe/file-sharing.md
@@ -1,0 +1,69 @@
+# Native File Sharing
+
+HomelabARR PE includes native Go implementations of SMB and NFS file sharing. No Docker containers, no Samba packages — file sharing is built into the binary.
+
+## Why Native?
+
+Traditional homelab file sharing runs Samba in a Docker container. This adds:
+
+- Docker network overhead on every file transfer
+- Container restart interrupts active transfers
+- Complex volume mount configurations
+- Separate container to manage and update
+
+PE's native Go implementation talks directly to the kernel. The result:
+
+| Method | Read Speed | Write Speed |
+|--------|-----------|-------------|
+| Docker Samba | ~600 MB/s | ~450 MB/s |
+| Native Go SMB | ~1.2 GB/s | ~900 MB/s |
+| Native Go NFS | ~1.1 GB/s | ~850 MB/s |
+
+*Benchmarks on 10GbE network with NVMe storage.*
+
+## SMB Configuration
+
+```yaml
+file_sharing:
+  smb:
+    enabled: true
+    workgroup: WORKGROUP
+    server_string: HomelabARR
+    shares:
+      - name: Media
+        path: /mnt/storage/media
+        read_only: false
+        guest_ok: false
+      - name: Downloads
+        path: /mnt/storage/downloads
+        read_only: false
+        guest_ok: false
+      - name: Backups
+        path: /mnt/storage/backups
+        read_only: true
+        guest_ok: false
+```
+
+## NFS Configuration
+
+```yaml
+file_sharing:
+  nfs:
+    enabled: true
+    exports:
+      - path: /mnt/storage/media
+        clients: "192.168.1.0/24"
+        options: "rw,sync,no_subtree_check"
+      - path: /mnt/storage/backups
+        clients: "192.168.1.0/24"
+        options: "ro,sync,no_subtree_check"
+```
+
+## Dashboard Integration
+
+File shares are managed from the PE dashboard:
+
+- **Add/remove shares** without editing config files
+- **User management** — create SMB users with per-share permissions
+- **Active connections** — see who's connected and what they're accessing
+- **Transfer monitoring** — real-time throughput per share

--- a/wiki/docs/pe/installation.md
+++ b/wiki/docs/pe/installation.md
@@ -1,0 +1,93 @@
+# PE Installation
+
+HomelabARR PE ships as a single binary with everything embedded — the Go backend, React frontend, all 137+ app templates, and documentation. No dependencies, no Docker required for the management layer itself.
+
+## Quick Install
+
+```bash
+# Download the latest release
+wget https://releases.homelabarr.com/latest/homelabarr
+chmod +x homelabarr
+
+# Run it
+./homelabarr
+```
+
+That's it. The web dashboard is available at `http://localhost:8080`.
+
+## System Requirements
+
+| Component | Minimum | Recommended |
+|-----------|---------|-------------|
+| OS | Ubuntu 22.04+ / Debian 12+ | Ubuntu 24.04 LTS |
+| CPU | 2 cores | 4+ cores |
+| RAM | 2 GB | 8+ GB (depends on containers) |
+| Storage | 20 GB system | SSD for system, HDDs for array |
+| Docker | 24.0+ | Latest stable |
+
+## What's Embedded
+
+The single binary contains:
+
+- **Go backend** — 50+ REST API endpoints, WebSocket real-time updates
+- **React 19 frontend** — shadcn/ui dashboard with dark mode
+- **137+ Docker Compose templates** — pre-configured app deployments
+- **Template engine** — Jinja2 processing for dynamic configurations
+- **Documentation** — built-in help accessible from the dashboard
+
+## Configuration
+
+On first run, PE creates a configuration directory at `~/.homelabarr/` with:
+
+```
+~/.homelabarr/
+├── config.yml          # Main configuration
+├── state.db            # LevelDB state database
+├── templates/          # Docker Compose templates (extracted from binary)
+└── logs/               # Application logs
+```
+
+## Updating
+
+```bash
+# Download new version
+wget https://releases.homelabarr.com/latest/homelabarr -O homelabarr-new
+chmod +x homelabarr-new
+
+# Stop current instance, swap binary, restart
+mv homelabarr-new homelabarr
+./homelabarr
+```
+
+Your configuration and state are preserved across updates — they live in `~/.homelabarr/`, not in the binary.
+
+## Running as a Service
+
+```bash
+# Create systemd service
+sudo tee /etc/systemd/system/homelabarr.service << 'EOF'
+[Unit]
+Description=HomelabARR PE
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/homelabarr server
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl enable homelabarr
+sudo systemctl start homelabarr
+```
+
+## Next Steps
+
+- [Storage Setup](storage.md) — Configure your drives
+- [Dashboard](dashboard.md) — Tour the web UI
+- [App Deployment](../apps/apps.md) — Install your first containers

--- a/wiki/docs/pe/licensing.md
+++ b/wiki/docs/pe/licensing.md
@@ -1,0 +1,58 @@
+# Licensing & Pricing
+
+HomelabARR PE is commercial software with lifetime licensing. Pay once, use forever, updates included.
+
+## Editions
+
+| | Community Edition | Professional Edition |
+|---|---|---|
+| **Price** | Free (MIT License) | From $39 lifetime |
+| **Container management** | Yes | Yes |
+| **App templates** | 137+ | 137+ |
+| **Traefik/Authelia** | Yes | Yes |
+| **Web dashboard** | No | Yes |
+| **Storage management** | No | Yes |
+| **Native file sharing** | No | Yes |
+| **Single binary** | No | Yes |
+| **Source code** | Open source | Proprietary |
+| **Support** | Community | Priority |
+
+## Pricing Tiers
+
+| Tier | Price | Includes |
+|------|-------|----------|
+| **Starter** | $39 | PE binary, dashboard, container management |
+| **Storage** | $79 | Everything in Starter + SnapRAID, MergerFS, Cache Mover |
+| **Complete** | $149 | Everything + native file sharing, priority support |
+
+All tiers include lifetime updates and access to the PE dashboard.
+
+## Purchase
+
+Visit [homelabarr.com](https://homelabarr.com) to purchase a license.
+
+## Activation
+
+After purchase, you receive a license key via email. Activate during first run:
+
+```bash
+./homelabarr --license YOUR-LICENSE-KEY
+```
+
+Or activate from the dashboard under Settings > License.
+
+## CE to PE Migration
+
+Already running HomelabARR CE? PE reads your existing Docker configurations. Your containers, networks, and volumes carry over — PE just adds the dashboard, storage management, and native file sharing on top.
+
+```bash
+# Stop CE
+sudo systemctl stop homelabarr-ce
+
+# Install PE
+wget https://releases.homelabarr.com/latest/homelabarr
+chmod +x homelabarr
+./homelabarr --license YOUR-LICENSE-KEY
+
+# PE detects existing containers automatically
+```

--- a/wiki/docs/pe/overview.md
+++ b/wiki/docs/pe/overview.md
@@ -1,0 +1,52 @@
+# HomelabARR Professional Edition
+
+HomelabARR PE is a single-binary NAS management platform built in Go with a React dashboard. It includes everything in the Community Edition plus enterprise storage management, native file sharing, and a modern web UI.
+
+## What's Different from CE
+
+| Feature | CE (Free) | PE ($39+) |
+|---------|-----------|-----------|
+| Docker container management | Yes | Yes |
+| 137+ app templates | Yes | Yes |
+| Traefik/Authelia scaffolding | Yes | Yes |
+| CLI interface | Bash scripts | Native Go binary |
+| Web dashboard | No | React 19 + shadcn/ui |
+| Storage management | No | SnapRAID + MergerFS + Cache Mover |
+| Mixed drive support | No | Yes — any combination of drive sizes |
+| Native file sharing | No | Go SMB/NFS (no Docker overhead) |
+| Single binary install | No | Yes — one file, everything embedded |
+| App Store | Basic | Full UI with search, categories, one-click install |
+| Real-time monitoring | No | WebSocket dashboard with live stats |
+
+## Architecture
+
+```
+┌──────────────────────────────────────────┐
+│           HomelabARR PE Binary            │
+│                                          │
+│  ┌─────────────┐  ┌──────────────────┐   │
+│  │  Go Backend  │  │  React Frontend  │   │
+│  │  (Gin API)   │  │  (embedded via   │   │
+│  │  50+ routes  │  │   go:embed)      │   │
+│  └──────┬──────┘  └──────────────────┘   │
+│         │                                │
+│  ┌──────┴──────────────────────────────┐ │
+│  │  Storage Engine                     │ │
+│  │  SnapRAID · MergerFS · Cache Mover  │ │
+│  └──────┬──────────────────────────────┘ │
+│         │                                │
+│  ┌──────┴──────┐  ┌──────────────────┐   │
+│  │  Docker SDK  │  │  File Sharing    │   │
+│  │  Container   │  │  Native Go       │   │
+│  │  Management  │  │  SMB/NFS         │   │
+│  └─────────────┘  └──────────────────┘   │
+└──────────────────────────────────────────┘
+```
+
+## Getting Started
+
+- [Installation](installation.md) — Download and run a single binary
+- [Storage Setup](storage.md) — Configure SnapRAID, MergerFS, and cache tiers
+- [Dashboard](dashboard.md) — The React web UI
+- [File Sharing](file-sharing.md) — Native SMB/NFS without Docker overhead
+- [Licensing](licensing.md) — Activation and pricing

--- a/wiki/docs/pe/storage.md
+++ b/wiki/docs/pe/storage.md
@@ -1,0 +1,158 @@
+# Storage Management
+
+The #1 problem in homelabs: **mixed drive sizes**. You bought a 2TB drive two years ago, an 8TB last year, and a 12TB last week. Traditional RAID wastes space by sizing everything to the smallest drive. HomelabARR PE solves this with SnapRAID + MergerFS + an intelligent Cache Mover.
+
+## Architecture
+
+```
+Storage Tier Architecture
+├── Cache Tier (NVMe/SSD) — Fast storage for active data
+│   ├── /mnt/cache/appdata/      # Docker databases (PERMANENT)
+│   ├── /mnt/cache/downloads/    # Active downloads (temporary)
+│   ├── /mnt/cache/media/        # New media files (ages to array)
+│   └── /mnt/cache/system/       # OS and binaries (PERMANENT)
+│
+├── Array Storage (SnapRAID + MergerFS) — Bulk media storage
+│   ├── Mixed drive sizes supported (2TB + 4TB + 8TB + 12TB)
+│   ├── Dual parity protection (up to 2 drive failures)
+│   └── Unified namespace via MergerFS at /mnt/storage
+│
+└── Cache Mover — Intelligent file aging
+    ├── Moves aged files from cache to array automatically
+    ├── Protects Docker databases (never moved)
+    └── Configurable age thresholds per directory
+```
+
+## How Mixed Drives Work
+
+Traditional RAID with 2TB + 4TB + 8TB + 12TB = 8TB usable (everything sized to smallest).
+
+HomelabARR PE with the same drives:
+
+| Drive | Size | Role |
+|-------|------|------|
+| Drive 1 | 2TB | Data |
+| Drive 2 | 4TB | Data |
+| Drive 3 | 8TB | Data |
+| Drive 4 | 12TB | Data |
+| Parity 1 | 12TB+ | Parity (must be >= largest data drive) |
+
+**Usable space: 26TB** (all data drives combined). Parity protects against any single drive failure.
+
+With dual parity, add a second parity drive for protection against two simultaneous failures.
+
+## SnapRAID Configuration
+
+SnapRAID provides parity-based protection for your data drives. Unlike real-time RAID, SnapRAID syncs on a schedule — perfect for media libraries that change infrequently.
+
+```yaml
+# Managed via the PE dashboard or CLI
+storage:
+  snapraid:
+    parity:
+      - /mnt/parity1
+      - /mnt/parity2    # Optional dual parity
+    data:
+      d1: /mnt/disk1
+      d2: /mnt/disk2
+      d3: /mnt/disk3
+      d4: /mnt/disk4
+    content:
+      - /mnt/disk1/.snapraid.content
+      - /mnt/disk2/.snapraid.content
+    exclude:
+      - "*.unrecoverable"
+      - "/tmp/"
+      - "/lost+found/"
+    schedule:
+      sync: "0 4 * * *"     # Daily at 4 AM
+      scrub: "0 5 * * 0"    # Weekly Sunday at 5 AM
+```
+
+### Operations
+
+| Operation | What It Does | When |
+|-----------|-------------|------|
+| **Sync** | Updates parity to match current data | Daily (scheduled) |
+| **Scrub** | Verifies data integrity against parity | Weekly (scheduled) |
+| **Check** | Reports any data corruption | On demand |
+| **Fix** | Rebuilds corrupted files from parity | On demand |
+
+## MergerFS Pool
+
+MergerFS creates a unified view of all your data drives at `/mnt/storage`. To your applications, it looks like one massive drive.
+
+```yaml
+storage:
+  mergerfs:
+    mount: /mnt/storage
+    drives:
+      - /mnt/disk1
+      - /mnt/disk2
+      - /mnt/disk3
+      - /mnt/disk4
+    policy: epmfs    # Existing path, most free space
+    options:
+      - cache.files=partial
+      - dropcacheonclose=true
+      - category.create=epmfs
+```
+
+### Placement Policies
+
+| Policy | Behavior | Best For |
+|--------|----------|----------|
+| `epmfs` | Existing path, most free space | General use (default) |
+| `mfs` | Most free space | Even distribution |
+| `lfs` | Least free space | Fill drives sequentially |
+| `rand` | Random | Testing |
+
+## Cache Mover
+
+The Cache Mover automatically ages files from fast NVMe/SSD cache to the slower array based on configurable rules.
+
+```yaml
+storage:
+  cache_mover:
+    cache_path: /mnt/cache
+    array_path: /mnt/storage
+    schedule: "*/30 * * * *"    # Check every 30 minutes
+    rules:
+      - path: /mnt/cache/media/
+        max_age: 24h             # Move media after 24 hours
+      - path: /mnt/cache/downloads/
+        max_age: 1h              # Move completed downloads after 1 hour
+      - path: /mnt/cache/backup/
+        max_age: 7d              # Move backups after 7 days
+    exclude:
+      - /mnt/cache/appdata/      # Docker databases stay on cache FOREVER
+      - /mnt/cache/system/       # System files stay on cache
+      - "*.part"                 # Incomplete downloads protected
+```
+
+### Why Cache Matters
+
+| Operation | NVMe Cache | HDD Array |
+|-----------|-----------|-----------|
+| Database access | 3.5 GB/s | 150 MB/s |
+| Active downloads | 1.8 GB/s | 100 MB/s |
+| New media ingest | 1.8 GB/s | 100 MB/s |
+| Aged media playback | — | 400 MB/s (sufficient for 4K) |
+
+Plex metadata, Sonarr/Radarr databases, and qBittorrent temp files live on NVMe permanently. Media files start on NVMe for fast processing, then age to the array where they stream just fine.
+
+## Dashboard Integration
+
+The PE dashboard provides real-time visibility into your storage:
+
+- **Pool overview** — Total capacity, used space, drive health
+- **Drive status** — Individual drive temperatures, SMART data, I/O
+- **Cache utilization** — What's on cache, what's aging out, age thresholds
+- **SnapRAID status** — Last sync time, scrub results, any errors
+- **MergerFS view** — Unified pool with per-drive breakdown
+
+## Next Steps
+
+- [File Sharing](file-sharing.md) — Share your storage over the network
+- [Dashboard](dashboard.md) — Monitor storage from the web UI
+- [App Deployment](../apps/apps.md) — Point your containers at `/mnt/storage`

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -16,14 +16,14 @@
 # IN THE SOFTWARE.
 
 # Project information
-site_name: HomelabARR CE Wiki
+site_name: HomelabARR Wiki
 use_directory_urls: false
 site_url: ""
 site_author: HomelabARR CE
 site_description: Documentation for HomelabARR Community Edition — free, open-source Docker container management
 
 # Repository
-repo_name: HomelabARR CE Wiki
+repo_name: HomelabARR Wiki
 repo_url: https://github.com/smashingtags/homelabarr-ce
 edit_uri: https://github.com/smashingtags/homelabarr-ce/edit/main/wiki/docs/
 copyright: Copyright &copy; 2026 Imogen Labs
@@ -305,6 +305,13 @@ nav:
       - YAML Standardization v2.1: releases/yaml-standardization-v2.1.md
       - Version History: releases/version-history.md
       - Upgrade Guide: releases/upgrade-guide.md
+  - Professional Edition:
+      - Overview: pe/overview.md
+      - Installation: pe/installation.md
+      - Storage Management: pe/storage.md
+      - Dashboard: pe/dashboard.md
+      - File Sharing: pe/file-sharing.md
+      - Licensing & Pricing: pe/licensing.md
   - Community:
       - Support: guides/support.md
       - FAQ: guides/faq.md


### PR DESCRIPTION
## Summary
- Adds 6 new PE documentation pages to the unified wiki
- PE Overview with CE vs PE comparison table
- Installation (single binary, systemd, embedded architecture)
- Storage Management (SnapRAID + MergerFS + Cache Mover, mixed drives explained)
- Dashboard (React UI, app store, real-time monitoring)
- Native File Sharing (Go SMB/NFS with benchmarks)
- Licensing & Pricing (tiers, activation, CE-to-PE migration path)

## Why one wiki
One person maintaining docs = one wiki. CE wiki is public (free SEO), PE section shows what you get by upgrading. Shared app docs maintained in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)