### PR TITLE
fix(wiki): rewrite install docs, fill empty pages, fix broken nav

### DIFF
--- a/wiki/docs/commands/backup.md
+++ b/wiki/docs/commands/backup.md
@@ -1,23 +1,127 @@
-![Image of HomelabARR CE](/img/container_images/docker-backup.png)
-
-<p align="left">
-    <a href="https://discord.gg/Pc7mXX786x">
-        <img src="https://discord.com/api/guilds/1334411584927301682/widget.png?label=Discord%20Server&logo=discord" alt="Join HomelabARR CE on Discord">
-    </a>
-        <a href="https://github.com/smashingtags/homelabarr-ce/releases">
-        <img src="https://img.shields.io/github/downloads/smashingtags/homelabarr-ce/total?label=Total%20Downloads&logo=github" alt="Total Releases Downloaded from GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/releases/latest">
-        <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
-    </a>
-</p>
-
 # Backup
 
-- Wiki Coming Soon .....
+HomelabARR CE includes `backup.sh` for backing up all container application data. Regular backups are the difference between a minor inconvenience and starting from scratch.
+
+## What Gets Backed Up
+
+The backup script targets `/opt/appdata` — the directory where all container configs, databases, and application state are stored. Each app gets its own compressed archive.
+
+!!! note
+    The script skips Traefik (`trae`), Authelia (`auth`), and Cloudflare (`cf`) containers during backup. Back those up separately (see below).
+
+## Running a Backup
+
+```bash
+sudo ./backup.sh
+```
+
+The script:
+
+1. Prunes unused Docker images to free space
+2. Pulls the latest `ghcr.io/smashingtags/homelabarr-backup` image
+3. Iterates through all running containers (except Traefik/Authelia/cf-companion)
+4. Creates a `.tar.gz` archive per container in `/mnt/downloads/appbackups/local/`
+5. Sets ownership to `1000:1000` on each archive
+6. Prunes Docker images again after completion
+
+### Backup Output
+
+Each container gets its own archive:
+
+```
+/mnt/downloads/appbackups/local/sonarr.tar.gz
+/mnt/downloads/appbackups/local/radarr.tar.gz
+/mnt/downloads/appbackups/local/plex.tar.gz
+...
+```
+
+## What to Back Up Manually
+
+The backup script covers appdata, but you should also preserve:
+
+### Environment Config
+
+```bash
+cp .env .env.backup
+cp apps/.config/.env apps/.config/.env.backup
+```
+
+These contain your domain, Cloudflare credentials, and all deployment variables. Losing these means reconfiguring everything.
+
+### Traefik Config
+
+```bash
+tar czf traefik-backup.tar.gz /opt/appdata/traefik/
+```
+
+Key files:
+- `/opt/appdata/traefik/rules/` — middleware definitions
+- `/opt/appdata/traefik/acme/acme.json` — SSL certificates
+- `/opt/appdata/traefik/traefik.log` — logs (optional)
+
+### Authelia Config
+
+```bash
+tar czf authelia-backup.tar.gz /opt/appdata/authelia/
+```
+
+Key files:
+- `/opt/appdata/authelia/configuration.yml` — Authelia settings
+- `/opt/appdata/authelia/users_database.yml` — user accounts and hashed passwords
+
+!!! warning
+    If you lose `users_database.yml`, you'll need to recreate all user accounts and passwords.
+
+### Docker Volumes
+
+Some containers use named Docker volumes instead of bind mounts. List them:
+
+```bash
+docker volume ls
+```
+
+Back up a specific volume:
+
+```bash
+docker run --rm -v volume_name:/data -v /opt/backup:/backup alpine \
+  tar czf /backup/volume_name.tar.gz -C /data .
+```
+
+## Recommended Strategy
+
+| Frequency | What | How |
+|-----------|------|-----|
+| Daily | Appdata (`backup.sh`) | Cron job or manual |
+| Weekly | Full system snapshot | Proxmox PBS, VM snapshot, or disk image |
+| After changes | `.env` files, Traefik/Authelia configs | Manual copy |
+| Monthly | Off-site copy | rsync to remote server or cloud storage |
+
+### Automating with Cron
+
+```bash
+# Run backup daily at 3 AM
+sudo crontab -e
+# Add:
+0 3 * * * /path/to/homelabarr-ce/backup.sh >> /var/log/homelabarr-backup.log 2>&1
+```
+
+!!! tip "Proxmox Users"
+    If HomelabARR CE runs in a Proxmox VM or LXC, use Proxmox Backup Server (PBS) for automated VM-level snapshots. This gives you bare-metal recovery in addition to app-level backups.
+
+## Verifying Backups
+
+Periodically verify your backups are usable:
+
+```bash
+# List contents of a backup archive
+tar tzf /mnt/downloads/appbackups/local/sonarr.tar.gz | head -20
+
+# Test extraction to a temp directory
+mkdir /tmp/backup-test
+tar xzf /mnt/downloads/appbackups/local/sonarr.tar.gz -C /tmp/backup-test
+ls /tmp/backup-test
+rm -rf /tmp/backup-test
+```
 
 ## Support
 

--- a/wiki/docs/commands/commands.md
+++ b/wiki/docs/commands/commands.md
@@ -1,28 +1,113 @@
-![Image of HomelabARR CE](/img/container_images/docker-homelabarr-ce.png)
+# CLI Command Reference
 
-<p align="left">
-    <a href="https://discord.gg/Pc7mXX786x">
-        <img src="https://discord.com/api/guilds/1334411584927301682/widget.png?label=Discord%20Server&logo=discord" alt="Join HomelabARR CE on Discord">
-    </a>
-        <a href="https://github.com/smashingtags/homelabarr-ce/releases">
-        <img src="https://img.shields.io/github/downloads/smashingtags/homelabarr-ce/total?label=Total%20Downloads&logo=github" alt="Total Releases Downloaded from GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/releases/latest">
-        <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
-    </a>
-</p>
+HomelabARR CE provides two interfaces for deploying containers: the **CLI** (`homelabarr-cli.sh`) and the **Web GUI**. Both use the same YAML templates and environment config.
 
-# Commands
+## Running the CLI
 
-- Wiki Coming Soon .....
+```bash
+cd homelabarr-ce
+./homelabarr-cli.sh
+```
+
+This opens an interactive menu with categorized app lists. Select a category, then pick an app to deploy.
+
+!!! note
+    The CLI must be run from the repo root directory so it can find the `apps/` templates and `.env` config.
+
+## Menu Categories
+
+The CLI organizes 179+ apps into categories:
+
+| Category | Examples |
+|----------|----------|
+| Media Servers | Plex, Jellyfin, Emby |
+| Download Clients | qBittorrent, SABnzbd, Deluge, NZBGet, ruTorrent |
+| Media Managers | Sonarr, Radarr, Lidarr, Bazarr, Prowlarr, Readarr |
+| Addons | Overseerr, Heimdall, Dashy, Portainer, Dozzle, Notifiarr |
+| Monitoring | Netdata, Tautulli, Uptime Kuma |
+| Encoding | Tdarr, Handbrake, Unmanic |
+| Backup | Duplicati, Restic, rsnapshot |
+| Coding | Code-Server, Cloud9, Coder |
+| Kasm Workspace | Chrome, Firefox, Discord, Steam, VLC |
+| System | Mount Enhanced, Cloudflare DDNS |
+
+## How Deployment Works
+
+When you select an app, the CLI:
+
+1. Reads the YAML template from `apps/<category>/<app>.yml`
+2. Substitutes environment variables from `apps/.config/.env` (or `.env` in the repo root for Full Mode)
+3. Deploys the container via `docker compose`
+
+### Template Structure
+
+Each app template is a standard Docker Compose YAML with variable substitution:
+
+```yaml
+services:
+  sonarr:
+    container_name: "sonarr"
+    image: "lscr.io/linuxserver/sonarr:latest"
+    environment:
+      - "PGID=${ID}"
+      - "PUID=${ID}"
+      - "TZ=${TZ}"
+    volumes:
+      - "${APPFOLDER}/sonarr:/config:rw"
+      - "unionfs:/mnt"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.sonarr-rtr.rule=Host(`sonarr.${DOMAIN}`)"
+      # ... more Traefik labels
+```
+
+## Environment Variables
+
+The CLI uses these variables from your `.env` file:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `APPFOLDER` | `/opt/appdata` | Where container configs are stored |
+| `DOMAIN` | — | Your domain (Full Mode only) |
+| `TZ` | `America/New_York` | Timezone |
+| `ID` | `1000` | UID/GID for file permissions |
+| `UMASK` | `002` | File creation mask |
+| `DOCKERNETWORK` | `proxy` | Docker network name |
+| `RESTARTAPP` | `unless-stopped` | Container restart policy |
+| `SECURITYOPS` | `no-new-privileges` | Security option |
+| `CLOUDFLARE_EMAIL` | — | Cloudflare email (Full Mode) |
+| `CLOUDFLARE_API_KEY` | — | Cloudflare API key (Full Mode) |
+
+Copy `apps/.config/.env.example` to `apps/.config/.env` and edit for your setup.
+
+## install.sh Menu
+
+The top-level `install.sh` provides two options:
+
+| Option | What It Does |
+|--------|-------------|
+| **1** | Installs Traefik + Authelia + cf-companion (Full Mode infrastructure) |
+| **2** | Opens the application deployment menu (same as `homelabarr-cli.sh`) |
+
+!!! tip
+    If you just want Local Mode (direct port access, no domain needed), skip Option 1 and go straight to Option 2. Or use the web GUI.
+
+## Local Mode vs Full Mode
+
+| Feature | Local Mode | Full Mode |
+|---------|-----------|-----------|
+| Access method | `http://server-ip:port` | `https://app.yourdomain.com` |
+| SSL | No | Yes (Let's Encrypt via Traefik) |
+| Authentication | Per-app | Authelia SSO |
+| Cloudflare | Not needed | Required |
+| Templates used | `*-local-template.yml` | Standard `*.yml` |
+
+## Web GUI
+
+The web GUI provides the same deployment functionality with a visual interface. It reads the same YAML templates and environment config. See the [Quick Start Guide](../guides/quick-start.md) for setup.
 
 ## Support
 
 Kindly report any issues/broken-parts/bugs on [github](https://github.com/smashingtags/homelabarr-ce/issues) or [discord](https://discord.gg/Pc7mXX786x)
 
 - Join our [![Discord: https://discord.gg/Pc7mXX786x](https://img.shields.io/badge/Discord-gray.svg?style=for-the-badge)](https://discord.gg/Pc7mXX786x) for Support
-
-**☕ [Support Development](https://ko-fi.com/homelabarr)** - Help us expand the command library and improve CLI functionality!

--- a/wiki/docs/commands/restore.md
+++ b/wiki/docs/commands/restore.md
@@ -1,23 +1,169 @@
-![Image of HomelabARR CE](/img/container_images/docker-homelabarr-ce.png)
-
-<p align="left">
-    <a href="https://discord.gg/Pc7mXX786x">
-        <img src="https://discord.com/api/guilds/1334411584927301682/widget.png?label=Discord%20Server&logo=discord" alt="Join HomelabARR CE on Discord">
-    </a>
-        <a href="https://github.com/smashingtags/homelabarr-ce/releases">
-        <img src="https://img.shields.io/github/downloads/smashingtags/homelabarr-ce/total?label=Total%20Downloads&logo=github" alt="Total Releases Downloaded from GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/releases/latest">
-        <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
-    </a>
-</p>
-
 # Restore
 
-- Wiki Coming Soon .....
+This guide covers restoring HomelabARR CE containers from backups created by `backup.sh` or manual archives.
+
+## Before You Start
+
+Make sure you have:
+
+- A working Docker installation
+- The HomelabARR CE repo cloned
+- Your `.env` file (or a backup copy of it)
+- Your backup archives from `/mnt/downloads/appbackups/local/`
+
+!!! warning
+    Stop any running containers for the apps you're restoring before overwriting their data. Running containers with changing data underneath them can cause corruption.
+
+## Restoring Appdata
+
+### Step 1: Stop Containers
+
+```bash
+# Stop all containers
+docker stop $(docker ps -q)
+
+# Or stop a specific app
+docker stop sonarr
+```
+
+### Step 2: Extract Backup Archives
+
+The backup archives contain appdata directories. Extract them back to `/opt/appdata`:
+
+```bash
+# Restore a single app
+tar xzf /mnt/downloads/appbackups/local/sonarr.tar.gz -C /opt/appdata
+
+# Restore all apps
+for archive in /mnt/downloads/appbackups/local/*.tar.gz; do
+  tar xzf "$archive" -C /opt/appdata
+done
+```
+
+### Step 3: Fix Permissions
+
+```bash
+chown -R 1000:1000 /opt/appdata
+```
+
+This matches the default `ID=1000` in the `.env` file. If you use a different UID/GID, adjust accordingly.
+
+!!! tip
+    Some apps (like Plex) create internal files with specific ownership. If an app won't start after restore, check its logs for permission errors and adjust with `chown -R 1000:1000 /opt/appdata/appname`.
+
+## Restoring Environment Config
+
+Copy your backed-up `.env` files into place:
+
+```bash
+cp .env.backup .env
+cp apps/.config/.env.backup apps/.config/.env
+```
+
+If you don't have a backup of your `.env`, copy the example and reconfigure:
+
+```bash
+cp apps/.config/.env.example apps/.config/.env
+# Edit with your settings: DOMAIN, CLOUDFLARE_EMAIL, TZ, etc.
+```
+
+## Restoring Traefik and Authelia
+
+### Traefik
+
+```bash
+# If you have a Traefik backup archive
+tar xzf traefik-backup.tar.gz -C /
+
+# Fix acme.json permissions (required by Traefik)
+chmod 600 /opt/appdata/traefik/acme/acme.json
+```
+
+!!! note
+    If you don't have a Traefik backup, re-run `./install.sh` (Option 1) to redeploy Traefik. It will request new SSL certificates automatically.
+
+### Authelia
+
+```bash
+tar xzf authelia-backup.tar.gz -C /
+```
+
+Key files to verify after restore:
+
+- `/opt/appdata/authelia/configuration.yml` — must reference your domain
+- `/opt/appdata/authelia/users_database.yml` — contains user accounts
+
+If `users_database.yml` is missing, Authelia won't have any users. You'll need to recreate it from the template in `traefik/templates/authelia/users_database.yml` and set new passwords.
+
+## Restoring Docker Volumes
+
+If you backed up named Docker volumes:
+
+```bash
+# Recreate the volume
+docker volume create volume_name
+
+# Restore data into it
+docker run --rm -v volume_name:/data -v /opt/backup:/backup alpine \
+  sh -c "tar xzf /backup/volume_name.tar.gz -C /data"
+```
+
+## Re-deploying Containers
+
+After restoring data, redeploy your containers. They'll pick up the existing configs from `/opt/appdata`.
+
+### Full Mode (Traefik)
+
+```bash
+# Redeploy infrastructure first
+./install.sh
+# Select Option 1 (Traefik + Authelia)
+
+# Then redeploy apps
+./homelabarr-cli.sh
+# Select each app to redeploy
+```
+
+### Local Mode
+
+```bash
+./homelabarr-cli.sh
+# Select apps to redeploy — they'll find their existing data in /opt/appdata
+```
+
+!!! tip
+    Containers are stateless by design. The app data lives in `/opt/appdata`. Redeploying a container with the same volume mounts picks up right where you left off.
+
+## Post-Restore Checklist
+
+After restoring, verify everything works:
+
+```bash
+# Check all containers are running
+docker ps
+
+# Check for containers in restart loops
+docker ps -a --filter "status=restarting"
+
+# Check logs for errors
+docker logs sonarr 2>&1 | tail -20
+docker logs radarr 2>&1 | tail -20
+docker logs traefik 2>&1 | tail -20
+```
+
+### Things to Verify
+
+- [ ] All containers are running (`docker ps`)
+- [ ] No containers in crash loops (`docker ps -a --filter "status=restarting"`)
+- [ ] Apps are accessible (via IP:port for Local Mode, via domain for Full Mode)
+- [ ] Traefik dashboard loads at `https://traefik.yourdomain.com` (Full Mode)
+- [ ] Authelia login works (Full Mode)
+- [ ] Media libraries are intact in Plex/Jellyfin
+- [ ] Download clients have their configs (categories, paths, connections)
+- [ ] *arr apps have their indexers, download client connections, and media libraries
+
+!!! warning
+    If an app shows a blank setup wizard after restore, its config directory wasn't restored correctly. Check that the files exist in `/opt/appdata/appname/` and permissions are `1000:1000`.
 
 ## Support
 

--- a/wiki/docs/guides/quick-start.md
+++ b/wiki/docs/guides/quick-start.md
@@ -1,97 +1,121 @@
 # Quick Start Guide
 
-## Overview
-
-HomelabARR CE is a comprehensive Docker-based media server stack that provides automated deployment and management of 100+ self-hosted applications including Plex, Radarr, Sonarr, and more.
-
 ## Prerequisites
 
-- **OS**: Ubuntu 18.04+ or Debian 10+ (x86_64)
-- **RAM**: 4GB minimum, 8GB+ recommended
-- **Storage**: 20GB+ free space
-- **Domain**: Valid domain with Cloudflare DNS management
-- **Network**: Internet connection for downloads
+| Requirement | Details |
+|-------------|---------|
+| **Docker** | Docker Engine 24+ |
+| **Docker Compose** | v2 (included with Docker Engine) |
+| **OS** | Ubuntu 18.04+, Debian 10+, or any Linux with Docker (x86_64) |
+| **RAM** | 4GB minimum, 8GB+ recommended |
+| **Storage** | 20GB+ free space |
+| **Git** | Only required for Method 2 (CLI installation) |
 
-## Quick Installation
-
-### 1. Download and Setup
-
-```bash
-# Clone repository
-git clone https://github.com/smashingtags/homelabarr-ce.git
-cd homelabarr-ce
-
-# Make scripts executable (CRITICAL)
-chmod +x install.sh preinstall/install.sh preinstall/installer/ubuntu.sh
-chmod +x .installer/ubuntu.sh .installer/homelabber homelabarr-ce.sh
-find scripts/ traefik/ apps/ -name "*.sh" -exec chmod +x {} \;
-
-# Create compatibility symlink
-sudo ln -sf "$(pwd)" /opt/homelabarr
-```
-
-### 2. Run Installation
-
-```bash
-sudo ./install.sh
-```
-
-### 3. Installation Menu
-
-Choose from the main menu:
-
-1. **HomelabARR CE - Traefik + Authelia** (run this first)
-   - Sets up reverse proxy and authentication
-   - Configures SSL certificates
-   - Prepares infrastructure
-
-2. **HomelabARR CE - Applications** (run after Traefik)
-   - Installs media servers (Plex, Jellyfin)
-   - Deploys media managers (Radarr, Sonarr)
-   - Sets up download clients (qBittorrent, SABnzbd)
-
-## Quick Troubleshooting
-
-### Permission Errors
-```bash
-chmod +x install.sh
-find . -name "*.sh" -exec chmod +x {} \;
-```
-
-### Path Issues
-```bash
-sudo ln -sf "$(pwd)" /opt/homelabarr
-```
-
-### Docker Issues
-```bash
-# Verify Docker installation
-docker --version
-docker-compose --version
-
-# If missing, installer will handle it automatically
-```
-
-## Next Steps
-
-1. **Configure Domain**: Set up your Cloudflare DNS and API tokens
-2. **Setup Authelia**: Configure user authentication
-3. **Deploy Applications**: Use the CLI menu to install desired apps
-4. **Configure Media Paths**: Set up your media library structure
-
-## Access Your Services
-
-After installation:
-- **Main Dashboard**: `https://your-domain.com`
-- **Traefik Dashboard**: `https://traefik.your-domain.com`
-- **Authentication**: `https://auth.your-domain.com`
-
-## Getting Help
-
-- **Detailed Installation Guide**: [Linux Installation](../install/linux-installation.md)
-- **GitHub Issues**: Report bugs and feature requests
-- **Documentation**: Full wiki available in this site
+!!! note "No domain required"
+    Methods 1 and 3 work without a domain or Cloudflare account. You only need a domain for Method 2 (Traefik + SSL).
 
 ---
 
-**Ready to get started?** Run the installation commands above and follow the interactive menu!
+## Method 1: Docker Compose (Recommended)
+
+The fastest way to get HomelabARR CE running. Four commands, no domain required.
+
+```bash
+# Download the compose file
+curl -o homelabarr.yml https://raw.githubusercontent.com/smashingtags/homelabarr-ce/main/homelabarr.yml
+
+# Generate a JWT secret and detect your Docker group ID
+export JWT_SECRET=$(openssl rand -base64 32)
+export DOCKER_GID=$(getent group docker | cut -d: -f3)
+
+# Start HomelabARR CE
+docker compose -f homelabarr.yml up -d
+```
+
+Once the containers are up:
+
+1. Open **http://your-server-ip:8084** in your browser
+2. Log in with **admin / admin**
+3. Browse the app catalog (157+ apps)
+4. Click **Deploy** on any app to launch it
+
+!!! warning "Change the default password"
+    After first login, change the admin password immediately from the dashboard settings.
+
+!!! tip "Persisting your JWT secret"
+    If you plan to restart the stack later, save `JWT_SECRET` in a `.env` file next to `homelabarr.yml` so sessions survive restarts:
+    ```bash
+    echo "JWT_SECRET=$(openssl rand -base64 32)" > .env
+    echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+    ```
+
+---
+
+## Method 2: CLI Installation (Full Mode)
+
+For users who want the full stack: **Traefik reverse proxy + domain-based routing + SSL certificates + Authelia 2FA**.
+
+### Requirements (in addition to prerequisites above)
+
+- A domain name with [Cloudflare](https://dash.cloudflare.com/sign-up) DNS management
+- Cloudflare API token with Zone:Edit permissions
+
+### Installation
+
+```bash
+git clone https://github.com/smashingtags/homelabarr-ce.git
+cd homelabarr-ce
+chmod +x install.sh
+sudo ln -sf "$(pwd)" /opt/homelabarr
+sudo ./install.sh
+```
+
+The interactive menu will guide you through:
+
+1. **Option 1: Traefik + Authelia** — Sets up reverse proxy, SSL, and authentication (run this first)
+2. **Option 2: Applications** — Deploys media servers, managers, and download clients
+
+After installation, access your services at:
+
+- `https://your-domain.com` — Main dashboard
+- `https://traefik.your-domain.com` — Traefik dashboard
+- `https://auth.your-domain.com` — Authelia login
+
+---
+
+## Method 3: Local Mode
+
+No domain, no Traefik, no SSL. Containers are accessed directly by port number. Ideal for testing or LAN-only setups.
+
+```bash
+git clone https://github.com/smashingtags/homelabarr-ce.git
+cd homelabarr-ce
+chmod +x install.sh
+sudo ./install.sh --local
+```
+
+Apps are accessible at `http://your-server-ip:<port>` (e.g., Plex at `:32400`, Radarr at `:7878`).
+
+See the [Local Mode Setup](../install/local-mode.md) guide for details.
+
+---
+
+## Next Steps
+
+- **[Dashboard Guide](../guides/repository-structure.md)** — Understand the project layout
+- **[App Catalog](../guides/architecture.md)** — How the 157+ app templates work
+- **[Traefik + Domain Setup](../install/linux-installation.md)** — Full CLI installation walkthrough
+- **[Contributing](../guides/contributing.md)** — Help improve HomelabARR CE
+
+---
+
+## Quick Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `Permission denied` on scripts | `chmod +x install.sh && find . -name "*.sh" -exec chmod +x {} \;` |
+| Path errors mentioning `/opt/homelabarr` | `sudo ln -sf "$(pwd)" /opt/homelabarr` |
+| Docker not found | `curl -fsSL https://get.docker.com \| sh` |
+| Can't reach dashboard on :8084 | Check `docker ps` — containers may still be starting |
+
+For detailed troubleshooting, see the [Linux Installation Guide](../install/linux-installation.md#troubleshooting).

--- a/wiki/docs/guides/support.md
+++ b/wiki/docs/guides/support.md
@@ -33,7 +33,7 @@
 
 ### 🔍 Check Documentation First
 1. **Quick Start Guide** - [guides/quick-start.md](quick-start.md)
-2. **Installation Guides** - [install/install.md](../install/install.md) or [install/local-mode.md](../install/local-mode.md)
+2. **Installation Guides** - [install/install.md](../guides/quick-start.md) or [install/local-mode.md](../install/local-mode.md)
 3. **FAQ Section** - [guides/faq.md](faq.md)
 4. **Application Docs** - [apps/apps.md](../apps/apps.md)
 

--- a/wiki/docs/index.md
+++ b/wiki/docs/index.md
@@ -6,7 +6,7 @@
     </a>
 </p>
 
------ 
+-----
 
 <p align="center">
     </br>
@@ -28,13 +28,25 @@
     </br>
 </p>
 
-_Docker + Traefik with Authelia and Cloudflare Protection_
+_Docker container management for homelabs. 157+ apps, one-click deploy. Optional Traefik reverse proxy with Authelia 2FA._
+
+---
+
+!!! tip "Quick Start -- Up and running in 60 seconds"
+    ```bash
+    curl -o homelabarr.yml https://raw.githubusercontent.com/smashingtags/homelabarr-ce/main/homelabarr.yml
+    export JWT_SECRET=$(openssl rand -base64 32)
+    export DOCKER_GID=$(getent group docker | cut -d: -f3)
+    docker compose -f homelabarr.yml up -d
+    ```
+    Open **http://your-server-ip:8084**, log in with **admin / admin**, and start deploying apps.
+    See the **[Quick Start Guide](guides/quick-start.md)** for all installation methods.
 
 ---
 
 ## Migration
 
-If you currently have a server with PG/MHS/PTS, have a look here before you start the installation: [Migration Guide](migration.md)
+If you currently have a server with PG/MHS/PTS, have a look here before you start the installation: [Migration Guide](install/migration.md)
 
 ---
 
@@ -48,8 +60,8 @@ If you currently have a server with PG/MHS/PTS, have a look here before you star
 - 20GB Disk Space
 
 - A VPS/VM or Dedicated Server
-- your Domain or buy a new [namecheap](https://www.namecheap.com/)
-- [Cloudflare](https://dash.cloudflare.com/sign-up) account free tier
+- your Domain or buy a new [namecheap](https://www.namecheap.com/) _(only required for Traefik setup)_
+- [Cloudflare](https://dash.cloudflare.com/sign-up) account free tier _(only required for Traefik setup)_
 
 ---
 
@@ -62,6 +74,9 @@ If you currently have a server with PG/MHS/PTS, have a look here before you star
 ---
 
 ## Pre-Install
+
+!!! note "Only required for Traefik + domain setup (Method 2)"
+    If you're using the Docker Compose method, skip this section and go straight to the [Quick Start Guide](guides/quick-start.md).
 
 1. Login to your Cloudflare Account & goto DNS click on Add record.
 1. Add 1 **A-Record** pointed to your server's ip.
@@ -80,17 +95,17 @@ If you currently have a server with PG/MHS/PTS, have a look here before you star
 
 ---
 
-### Easy Mode install
+### Install
 
-Follow our install instructions: [Install Guide](install/install.md)
+Follow our install instructions: [Quick Start Guide](guides/quick-start.md)
 
 ---
 
-## 📚 Documentation & Guides
+## Documentation & Guides
 
 ### Getting Started
-- **[Installation Guide](install/install.md)** - Complete setup instructions
-- **[Quick Start Guide](guides/quick-start.md)** - Get up and running fast
+- **[Quick Start Guide](guides/quick-start.md)** - All installation methods (Docker Compose, CLI, Local)
+- **[Linux Installation Guide](install/linux-installation.md)** - Detailed Linux setup instructions
 - **[Local Mode Setup](install/local-mode.md)** - Testing and development setup
 
 ### Advanced Topics
@@ -110,7 +125,7 @@ Follow our install instructions: [Install Guide](install/install.md)
 
 Kindly report any issues/broken-parts/bugs on [github](https://github.com/smashingtags/homelabarr-ce/issues) or [discord](https://discord.gg/Pc7mXX786x)
 
-**☕ [Support Development](https://ko-fi.com/homelabarr)** - Help keep HomelabARR CE growing!
+**[Support Development](https://ko-fi.com/homelabarr)** - Help keep HomelabARR CE growing!
 
 ---
 
@@ -125,7 +140,7 @@ Co-Dev -APPS- @CONTRIBUTORS-LIST
 
 ---
 
-## Contributors ✨
+## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 

--- a/wiki/docs/install/cloudflare.md
+++ b/wiki/docs/install/cloudflare.md
@@ -1,23 +1,109 @@
-![Image of HomelabARR CE](/img/container_images/docker-homelabarr-ce.png)
+# Cloudflare Setup
 
-<p align="left">
-    <a href="https://discord.gg/Pc7mXX786x">
-        <img src="https://discord.com/api/guilds/1334411584927301682/widget.png?label=Discord%20Server&logo=discord" alt="Join HomelabARR CE on Discord">
-    </a>
-        <a href="https://github.com/smashingtags/homelabarr-ce/releases">
-        <img src="https://img.shields.io/github/downloads/smashingtags/homelabarr-ce/total?label=Total%20Downloads&logo=github" alt="Total Releases Downloaded from GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/releases/latest">
-        <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
-    </a>
-</p>
+Cloudflare provides DNS management and SSL certificates for HomelabARR CE **Full Mode** (Traefik + custom domain). If you're using Local Mode or Docker Compose mode, you can skip this entirely.
 
-# Cloudflare
+!!! note "Full Mode Only"
+    Cloudflare is only required when running Traefik with a public domain. Local Mode deploys containers with direct port access and doesn't need DNS or SSL.
 
-- Wiki Coming Soon .....
+## Create a Cloudflare Account
+
+1. Sign up at [dash.cloudflare.com](https://dash.cloudflare.com)
+2. Add your domain — Cloudflare will scan existing DNS records
+3. Update your domain registrar's nameservers to the ones Cloudflare provides
+4. Wait for nameserver propagation (usually 5-30 minutes, can take up to 24 hours)
+
+## Add a DNS Record
+
+Create an **A record** pointing to your server's public IP:
+
+| Type | Name | Content | Proxy | TTL |
+|------|------|---------|-------|-----|
+| A | `@` | Your server's public IP | Proxied (orange cloud) | Auto |
+
+!!! tip
+    If you don't know your public IP, run `curl -s ifconfig.me` on your server.
+
+The **cf-companion** container (deployed with Traefik) automatically creates CNAME records for each app you deploy, so you only need this one A record.
+
+## Get Your API Credentials
+
+### Global API Key
+
+1. Go to [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)
+2. Under **API Keys**, click **View** next to **Global API Key**
+3. Enter your password and complete the CAPTCHA
+4. Copy the key
+
+### Zone ID
+
+1. Go to your domain's overview page in Cloudflare
+2. Scroll to the bottom-right sidebar
+3. Copy the **Zone ID**
+
+## Environment Variables
+
+Add these to your `.env` file (in the repo root):
+
+```bash
+DOMAIN=yourdomain.com
+CLOUDFLARE_EMAIL=your-email@example.com
+CLOUDFLARE_API_KEY=your-global-api-key
+DOMAIN1_ZONE_ID=your-zone-id
+```
+
+These are used by both Traefik (for ACME DNS challenge) and cf-companion (for automatic DNS record creation).
+
+## SSL/TLS Settings
+
+In Cloudflare dashboard, go to **SSL/TLS** for your domain and configure:
+
+### SSL Mode
+
+**SSL/TLS > Overview**: Set encryption mode to **Full (Strict)**
+
+This tells Cloudflare to encrypt traffic end-to-end and validate Traefik's certificate. Since Traefik gets a real Let's Encrypt cert via DNS challenge, Full (Strict) works correctly.
+
+!!! warning
+    Do not use "Flexible" mode. It creates a redirect loop because Traefik forces HTTPS.
+
+### Edge Certificates
+
+Go to **SSL/TLS > Edge Certificates** and set:
+
+| Setting | Value |
+|---------|-------|
+| Always Use HTTPS | On |
+| Minimum TLS Version | 1.2 |
+| TLS 1.3 | On |
+
+### Settings to Disable
+
+Go to **Speed > Optimization** and disable:
+
+- **Rocket Loader** — Off (interferes with websockets used by apps like Sonarr/Radarr)
+- **Brotli** — Off (can cause issues with websocket connections)
+
+!!! tip
+    If you experience random disconnects or blank pages in *arr apps, check that Rocket Loader is disabled first.
+
+## Verifying It Works
+
+After deploying Traefik (see [Traefik docs](traefik.md)):
+
+1. Check that `https://traefik.yourdomain.com` loads the Traefik dashboard
+2. Check that your app subdomains resolve: `dig app.yourdomain.com`
+3. Verify SSL: `curl -vI https://app.yourdomain.com 2>&1 | grep "issuer"`
+
+You should see a Let's Encrypt certificate, not a Cloudflare origin cert.
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| ERR_TOO_MANY_REDIRECTS | SSL mode set to Flexible | Change to Full (Strict) |
+| 502 Bad Gateway | Cloudflare can't reach your server | Check A record IP, check Traefik is running, check firewall ports 80/443 |
+| SSL certificate error | ACME challenge failed | Check `CLOUDFLARE_EMAIL` and `CLOUDFLARE_API_KEY` are correct |
+| Apps not getting subdomains | cf-companion not running | Check `docker logs cf-companion` |
 
 ## Support
 

--- a/wiki/docs/install/linux-installation.md
+++ b/wiki/docs/install/linux-installation.md
@@ -1,12 +1,66 @@
 # Linux Installation Guide
 
-## Overview
+---
 
-This guide covers the complete installation process for HomelabARR CE on Linux systems (Ubuntu/Debian). The installer has been fixed to work properly from any directory location and includes comprehensive error handling.
+## Method 1: Docker Compose (Recommended)
 
-## Prerequisites
+The fastest path to a running HomelabARR CE instance. No domain, no Traefik, no git clone required.
 
-### System Requirements
+### Requirements
+
+- **Docker Engine 24+** with **Docker Compose v2**
+- Linux x86_64 (Ubuntu 18.04+, Debian 10+, or any distro with Docker)
+- 4GB RAM minimum, 8GB+ recommended
+
+### Install in 4 Commands
+
+```bash
+# 1. Download the compose file
+curl -o homelabarr.yml https://raw.githubusercontent.com/smashingtags/homelabarr-ce/main/homelabarr.yml
+
+# 2. Generate a JWT secret
+export JWT_SECRET=$(openssl rand -base64 32)
+
+# 3. Detect your Docker socket group ID
+export DOCKER_GID=$(getent group docker | cut -d: -f3)
+
+# 4. Start the stack
+docker compose -f homelabarr.yml up -d
+```
+
+### Environment Variables
+
+| Variable | Purpose | How to set |
+|----------|---------|------------|
+| `JWT_SECRET` | Signs auth tokens for the dashboard | `openssl rand -base64 32` |
+| `DOCKER_GID` | Grants the container access to the Docker socket | `getent group docker \| cut -d: -f3` |
+| `CLI_BRIDGE_HOST_PATH` | (Optional) Host path for CLI bridge scripts | Defaults to internal path if unset |
+
+### Accessing the Dashboard
+
+Open **http://your-server-ip:8084** in your browser. Default login: **admin / admin**.
+
+From the dashboard you can browse 157+ app templates and deploy them with one click.
+
+!!! tip "Persist environment variables"
+    Create a `.env` file next to `homelabarr.yml` so the stack survives restarts:
+    ```bash
+    echo "JWT_SECRET=$(openssl rand -base64 32)" > .env
+    echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+    ```
+
+!!! note "For Traefik + domain setup, see Method 2 below"
+    The Docker Compose method gives you the dashboard and one-click deploys. If you also want a reverse proxy with SSL and Authelia 2FA, continue with the CLI installation.
+
+---
+
+## Method 2: CLI Installation (Full Mode)
+
+This is the original installation method. It sets up Traefik, Authelia, Cloudflare DNS integration, and SSL certificates in addition to the app deployment system.
+
+### Prerequisites
+
+#### System Requirements
 - **Operating System**: Ubuntu 18.04+ or Debian 10+
 - **Architecture**: x86_64 (ARM not supported)
 - **RAM**: Minimum 4GB, Recommended 8GB+
@@ -14,19 +68,17 @@ This guide covers the complete installation process for HomelabARR CE on Linux s
 - **CPU**: 2+ cores recommended
 - **Network**: Internet connection for container downloads
 
-### Required Dependencies
+#### Required Dependencies
 The installer will automatically install these if missing:
 - **Docker**: Latest stable version
 - **Docker Compose**: v2.0+
 - **Git**: For repository management
 - **Curl/Wget**: For downloading components
 
-### Domain and DNS Requirements
+#### Domain and DNS Requirements
 - Valid domain name with Cloudflare DNS management
 - Cloudflare API token with Zone:Edit permissions
 - Subdomain configuration capability
-
-## Installation Process
 
 ### Step 1: Download and Prepare
 
@@ -77,9 +129,9 @@ After running the installer, you'll see the main menu:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    🚀 HomelabARR CE
+    HomelabARR CE
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    
+
     [ 1 ] HomelabARR CE - Traefik + Authelia
     [ 2 ] HomelabARR CE - Applications
 

--- a/wiki/docs/install/local-mode.md
+++ b/wiki/docs/install/local-mode.md
@@ -588,7 +588,7 @@ docker ps
 ### What's Next?
 - Start adding your media files to the configured directories
 - Explore additional [applications](../apps/apps.md) from our collection
-- Consider upgrading to [Full Mode](install.md) when you're ready for external access
+- Consider upgrading to [Full Mode](../guides/quick-start.md) when you're ready for external access
 - Join our [Discord community](https://discord.gg/Pc7mXX786x) for tips and support
 
 ### Support Development

--- a/wiki/docs/install/migration.md
+++ b/wiki/docs/install/migration.md
@@ -85,7 +85,7 @@ This creates `/appbackups/` directory with all application configurations and da
 Follow the standard installation on your host system:
 
 1. Order VPS or prepare local server with Ubuntu 22.04
-2. Follow installation instructions in the [Install Guide](install.md)
+2. Follow installation instructions in the [Install Guide](../guides/quick-start.md)
 3. Return here once HomelabARR CE is installed
 
 ## 4. Configure Local Storage Integration

--- a/wiki/docs/install/traefik.md
+++ b/wiki/docs/install/traefik.md
@@ -1,24 +1,180 @@
-![Image of HomelabARR CE](/img/container_images/docker-homelabarr-ce.png)
+# Traefik Reverse Proxy
 
-<p align="left">
-    <a href="https://discord.gg/Pc7mXX786x">
-        <img src="https://discord.com/api/guilds/1334411584927301682/widget.png?label=Discord%20Server&logo=discord" alt="Join HomelabARR CE on Discord">
-    </a>
-        <a href="https://github.com/smashingtags/homelabarr-ce/releases">
-        <img src="https://img.shields.io/github/downloads/smashingtags/homelabarr-ce/total?label=Total%20Downloads&logo=github" alt="Total Releases Downloaded from GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/releases/latest">
-        <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
-    </a>
-    <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
-    </a>
-</p>
+Traefik is the reverse proxy that makes your apps accessible at `https://app.yourdomain.com` with automatic SSL certificates. It's the core of HomelabARR CE **Full Mode**.
 
-# Treafik
+## What Traefik Does
 
-- Wiki Coming Soon .....
- 
+- Routes incoming traffic to the right container based on hostname
+- Handles SSL/TLS certificates via Let's Encrypt (ACME DNS challenge through Cloudflare)
+- Applies security middleware (rate limiting, secure headers, authentication via Authelia)
+- Redirects HTTP to HTTPS automatically
+
+HomelabARR CE deploys Traefik 3.5 alongside **Authelia** (authentication portal) and **cf-companion** (automatic Cloudflare DNS record creation).
+
+## Installation
+
+### Via install.sh (Recommended)
+
+```bash
+cd homelabarr-ce
+./install.sh
+# Select Option 1 — installs Traefik + Authelia + cf-companion
+```
+
+This runs `traefik/install.sh`, which detects your OS (Ubuntu/Debian) and calls the appropriate installer script.
+
+### Prerequisites
+
+Before installing, make sure your `.env` file has:
+
+```bash
+DOMAIN=yourdomain.com
+CLOUDFLARE_EMAIL=your-email@example.com
+CLOUDFLARE_API_KEY=your-global-api-key
+DOMAIN1_ZONE_ID=your-zone-id
+APPFOLDER=/opt/appdata
+DOCKERNETWORK=proxy
+ID=1000
+TZ=America/New_York
+```
+
+See [Cloudflare Setup](cloudflare.md) for getting the Cloudflare credentials.
+
+### The Proxy Network
+
+All containers that Traefik routes to must be on the `proxy` Docker network:
+
+```bash
+docker network create proxy
+```
+
+The installer handles this, but if you're troubleshooting, verify it exists with `docker network ls`.
+
+## How Routing Works
+
+Traefik discovers containers via Docker labels. When you deploy an app through HomelabARR CE, the YAML template includes labels like:
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.docker.network=proxy"
+  - "traefik.http.routers.sonarr-rtr.entrypoints=https"
+  - "traefik.http.routers.sonarr-rtr.rule=Host(`sonarr.${DOMAIN}`)"
+  - "traefik.http.routers.sonarr-rtr.tls=true"
+  - "traefik.http.routers.sonarr-rtr.tls.certresolver=dns-cloudflare"
+  - "traefik.http.routers.sonarr-rtr.middlewares=chain-authelia@file"
+  - "traefik.http.routers.sonarr-rtr.service=sonarr-svc"
+  - "traefik.http.services.sonarr-svc.loadbalancer.server.port=8989"
+```
+
+Breaking this down:
+
+| Label | Purpose |
+|-------|---------|
+| `traefik.enable=true` | Tells Traefik to route this container |
+| `traefik.docker.network=proxy` | Which Docker network to use |
+| `routers.APP-rtr.rule=Host(...)` | Match requests for this hostname |
+| `routers.APP-rtr.tls.certresolver=dns-cloudflare` | Use Cloudflare DNS for SSL cert |
+| `routers.APP-rtr.middlewares=chain-authelia@file` | Apply authentication middleware |
+| `services.APP-svc.loadbalancer.server.port` | Container's internal port |
+
+## Middleware Chains
+
+Middleware chains are defined in `/opt/appdata/traefik/rules/middlewares-chains.yml`:
+
+### chain-no-auth
+
+No authentication required. Applies rate limiting and secure headers only.
+
+```yaml
+chain-no-auth:
+  chain:
+    middlewares:
+      - middlewares-rate-limit
+      - middlewares-secure-headers
+```
+
+Use for apps that handle their own authentication (Plex, Overseerr) or public-facing services.
+
+### chain-authelia
+
+Full authentication via Authelia. Rate limiting + secure headers + Authelia forward auth.
+
+```yaml
+chain-authelia:
+  chain:
+    middlewares:
+      - middlewares-rate-limit
+      - middlewares-secure-headers
+      - middlewares-authelia
+```
+
+This is the default for most apps. Users hit Authelia's login page before reaching the app.
+
+!!! tip
+    To switch an app from `chain-authelia` to `chain-no-auth`, change the middleware label in the app's YAML template and redeploy.
+
+## SSL Certificates
+
+Traefik gets wildcard certificates from Let's Encrypt using the Cloudflare DNS challenge:
+
+- Certificate covers `yourdomain.com` and `*.yourdomain.com`
+- Stored in `/opt/appdata/traefik/acme/acme.json`
+- Auto-renews before expiry
+- DNS challenge means ports 80/443 don't need to be open for validation (but they do need to be open for serving traffic)
+
+## Traefik Dashboard
+
+Access at `https://traefik.yourdomain.com` (protected by Authelia).
+
+The dashboard shows:
+
+- Active routers and their rules
+- Services and their health
+- Middleware chains in use
+- Entrypoints (HTTP/HTTPS)
+
+## File Locations
+
+| File | Purpose |
+|------|---------|
+| `/opt/appdata/traefik/rules/` | Middleware configs (TOML and YAML) |
+| `/opt/appdata/traefik/acme/acme.json` | SSL certificates |
+| `/opt/appdata/traefik/traefik.log` | Access and error logs |
+
+## Troubleshooting
+
+### 404 Not Found
+
+**Traefik received the request but no router matched.**
+
+- Check the container is running: `docker ps | grep appname`
+- Check the container is on the `proxy` network: `docker inspect appname | grep -A5 Networks`
+- Check the Host rule matches the URL you're visiting
+- Check `traefik.enable=true` is set in the container's labels
+
+### 502 Bad Gateway
+
+**Traefik matched a route but can't reach the backend container.**
+
+- The container's internal port in the label doesn't match the actual port the app listens on
+- The container crashed — check `docker logs appname`
+- The container is not on the `proxy` network
+
+### 503 Service Unavailable
+
+**Middleware error, usually Authelia.**
+
+- Check Authelia is running: `docker ps | grep authelia`
+- Check Authelia logs: `docker logs authelia`
+- Verify `/opt/appdata/authelia/configuration.yml` is valid
+
+### Certificate Errors
+
+- Check Cloudflare credentials in `.env`
+- Check `acme.json` permissions: `chmod 600 /opt/appdata/traefik/acme/acme.json`
+- Check Traefik logs: `docker logs traefik 2>&1 | grep -i acme`
+
 ## Support
 
 Kindly report any issues/broken-parts/bugs on [github](https://github.com/smashingtags/homelabarr-ce/issues) or [discord](https://discord.gg/Pc7mXX786x)

--- a/wiki/docs/scripts/scripts.md
+++ b/wiki/docs/scripts/scripts.md
@@ -214,8 +214,8 @@ Want to contribute your own scripts? We welcome community contributions!
 
 For more detailed information:
 - [Maintenance Scripts](maintenance.md) - Deep dive into system maintenance
-- [Security Scripts](security.md) - Advanced security configurations
-- [Automation Scripts](automation.md) - Setting up automated workflows
+-  - Advanced security configurations
+-  - Setting up automated workflows
 
 ## Support
 

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -172,13 +172,10 @@ nav:
       - Local-Persist Plugin: setup/local-persist-integration.md
   - Deployment Guides:
       - Container Deployment: guides/deployment-guide.md
-      - Full Mode vs Local Mode: guides/deployment-comparison.md
-      - Production Setup: guides/production-setup.md
   - Developer Documentation:
       - Contributing: guides/contributing.md
       - Architecture Overview: guides/architecture.md
       - CLI Development: guides/cli-development.md
-      - Container Development: guides/container-development.md
       - YAML Cleanup Tool: guides/yaml-cleanup-tool.md
   - Commands:
       - Commands: commands/commands.md
@@ -242,7 +239,7 @@ nav:
           - Lidarr: apps/mediamanager/lidarr.md
           - Plex-Utills: apps/mediamanager/plex-utills.md
           - Prowlarr: apps/mediamanager/prowlarr.md
-          - Radarr: apps/mediamanager/radarr.md
+          #- Radarr: apps/mediamanager/radarr.md  # file missing
           - Readarr: apps/mediamanager/readarr.md
           - Sonarr: apps/mediamanager/sonarr.md
           - Tautulli: apps/mediamanager/tautulli.md
@@ -255,7 +252,7 @@ nav:
           - Plex: apps/mediaserver/plex.md
       - Request:
           - Conreq: apps/request/conreq.md
-          - Overseerr: apps/request/overseerr.md
+          #- Overseerr: apps/request/overseerr.md  # file missing
           - Petio: apps/request/petio.md
       - Selfhosted:
           - Alltube: apps/selfhosted/alltube.md
@@ -283,12 +280,12 @@ nav:
           - Wireguard: apps/selfhosted/wireguard.md
           - XBVR: apps/selfhosted/xbvr.md
       - Share:
-          - Filerun: apps/share/filerun.md
-          - Nextcloud: apps/share/nextcloud.md
-          - Projectsend: apps/share/projectsend.md
+          - Filerun: apps/selfhosted/share/filerun.md
+          - Nextcloud: apps/selfhosted/share/nextcloud.md
+          - Projectsend: apps/selfhosted/share/projectsend.md
       - System:
           - Mount: apps/system/mount.md
-          - Uploader: apps/system/uploader.md
+          #- Uploader: apps/system/uploader.md  # file missing
           - Dockupdater: apps/system/dockupdater.md
           - endlessh: apps/system/endlessh.md
           - Rclone-GUI: apps/system/rclone-gui.md
@@ -298,13 +295,10 @@ nav:
       - Scripts Overview: scripts/scripts.md
       - YAML Cleanup Script: scripts/yaml-cleanup.md
       - Maintenance Scripts: scripts/maintenance.md
-      - Security Scripts: scripts/security.md
-      - Automation Scripts: scripts/automation.md
   - Release Information:
       - Latest Release: releases/RELEASE-NOTES.md
       - YAML Standardization v2.1: releases/yaml-standardization-v2.1.md
       - Version History: releases/version-history.md
-      - Upgrade Guide: releases/upgrade-guide.md
   - Professional Edition:
       - Overview: pe/overview.md
       - Installation: pe/installation.md


### PR DESCRIPTION
## Summary (PR 1 of 3 — Wiki Overhaul)

### Install docs now lead with Docker Compose
- `quick-start.md` rewritten: Docker Compose GHCR first, CLI second, Local Mode third
- `linux-installation.md` gets Docker Compose section at the top
- `index.md` updated tagline, fixed broken links, added quick start callout

### 5 empty placeholder pages now have real content
- `cloudflare.md` — A record, API token, SSL settings, Zone ID
- `traefik.md` — Labels, middleware, ACME, proxy network, troubleshooting
- `commands.md` — CLI reference, menu categories, env vars
- `backup.md` — What backup.sh does, manual backup, cron
- `restore.md` — Step-by-step restore procedure

### Nav fixes
- Removed 6 references to non-existent files
- Fixed share app paths
- Fixed all broken `install.md` links → `quick-start.md`

## Test plan
- [x] `mkdocs build` passes (2 minor pre-existing warnings only)
- [ ] Visual review on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)