### PR TITLE
feat(wiki): web dashboard, API reference, CLI bridge docs

### DIFF
--- a/wiki/docs/guides/api-reference.md
+++ b/wiki/docs/guides/api-reference.md
@@ -1,0 +1,246 @@
+# API Reference
+
+The HomelabARR CE backend exposes a REST API on port **8084**. All endpoints return JSON. Protected endpoints require a JWT token in the `Authorization` header:
+
+```
+Authorization: Bearer <jwt-token>
+```
+
+Tokens are obtained from the login endpoint and expire after 24 hours by default (configurable via `JWT_EXPIRES_IN`).
+
+---
+
+## Authentication
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/auth/login` | None | Log in and receive a JWT token |
+| `POST` | `/auth/logout` | Required | Invalidate the current session |
+| `GET` | `/auth/me` | Required | Get the authenticated user's profile |
+| `POST` | `/auth/change-password` | Required | Change your password |
+| `GET` | `/auth/sessions` | Required | List your active sessions |
+| `DELETE` | `/auth/sessions/:sessionId` | Required | Revoke a specific session |
+| `POST` | `/auth/register` | Admin | Create a new user account |
+| `GET` | `/auth/users` | Admin | List all users |
+
+### POST /auth/login
+
+```json
+// Request
+{ "username": "admin", "password": "admin" }
+
+// Response
+{
+  "success": true,
+  "token": "eyJhbGciOiJIUzI1NiIs...",
+  "user": {
+    "id": "admin",
+    "username": "admin",
+    "email": "admin@homelabarr.local",
+    "role": "admin",
+    "lastLogin": "2024-01-15T10:30:00Z"
+  }
+}
+```
+
+### POST /auth/change-password
+
+```json
+// Request
+{ "currentPassword": "admin", "newPassword": "my-new-password" }
+// Response
+{ "success": true, "message": "Password changed successfully" }
+```
+
+### POST /auth/register (Admin only)
+
+```json
+// Request
+{ "username": "viewer", "password": "secret", "email": "user@example.com", "role": "user" }
+// Response
+{ "success": true, "user": { "id": "user_abc123", "username": "viewer", "role": "user" } }
+```
+
+---
+
+## Applications
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/applications` | None | List all apps from the CLI Bridge or template fallback |
+| `POST` | `/applications/:appId/stop` | Conditional | Stop an application's containers |
+| `DELETE` | `/applications/:appId` | Conditional | Remove an application (`?removeVolumes=true` to delete data) |
+| `GET` | `/applications/:appId/logs` | Conditional | Get application logs (`?lines=100`) |
+
+!!! note "Conditional auth"
+    When `AUTH_ENABLED=true` (default), these endpoints require a valid token. When auth is disabled, they accept unauthenticated requests.
+
+### GET /applications
+
+```json
+{
+  "success": true,
+  "source": "cli",
+  "applications": {
+    "mediaserver": [ { "id": "mediaserver-plex", "name": "plex", "displayName": "Plex", ... } ],
+    "downloadclients": [ ... ],
+    "mediamanager": [ ... ]
+  },
+  "totalApps": 112,
+  "categories": ["addons", "ai-tools", "backup", "coding", "downloadclients", ...]
+}
+```
+
+---
+
+## Deployment
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/deploy` | Conditional | Deploy an application |
+| `GET` | `/deployment-modes` | None | List available deployment modes |
+| `GET` | `/deployments/active` | Conditional | List in-progress deployments |
+| `GET` | `/deployments/:deploymentId/status` | Conditional | Get status of a specific deployment |
+
+### POST /deploy
+
+```json
+// Request
+{
+  "appId": "mediaserver-plex",
+  "config": {
+    "TZ": "America/New_York",
+    "ID": "1000",
+    "DOMAIN": "plex.example.com",
+    "APPFOLDER": "/opt/appdata"
+  },
+  "mode": { "type": "traefik" }
+}
+
+// Response (streaming mode)
+{
+  "success": true,
+  "message": "mediaserver-plex deployment started with real-time progress tracking",
+  "deploymentId": "550e8400-e29b-41d4-a716-446655440000",
+  "source": "cli-streaming",
+  "appId": "mediaserver-plex",
+  "streamEndpoint": "/stream/progress",
+  "statusEndpoint": "/deployments/550e8400-e29b-41d4-a716-446655440000/status"
+}
+```
+
+The `mode.type` field accepts: `standard`, `traefik`, or `authelia`.
+
+### GET /deployment-modes
+
+```json
+{
+  "success": true,
+  "modes": [
+    { "type": "standard", "name": "Standard", "description": "Basic Docker deployment without reverse proxy" },
+    { "type": "traefik", "name": "Traefik", "description": "Deployment with Traefik reverse proxy and SSL" },
+    { "type": "authelia", "name": "Traefik + Authelia", "description": "Full production deployment with authentication" }
+  ],
+  "cliAvailable": true
+}
+```
+
+---
+
+## Progress Streaming (SSE)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/stream/progress` | None | Open an SSE connection for real-time deployment events |
+| `POST` | `/stream/deployments/:deploymentId/subscribe` | Conditional | Subscribe an SSE client to a specific deployment |
+
+Connect to `/stream/progress` with an `EventSource`. The server assigns a `clientId` and pushes events as deployments progress. To filter events for a single deployment, call the subscribe endpoint with your `clientId` and the target `deploymentId`.
+
+---
+
+## Containers
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/containers` | Conditional | List all Docker containers (`?stats=true` for CPU/memory) |
+| `GET` | `/containers/:id/stats` | None | Get live stats for a single container |
+| `GET` | `/containers/:id/logs` | None | Get container logs (`?tail=100&timestamps=true`) |
+| `POST` | `/containers/:id/start` | Conditional | Start a stopped container |
+| `POST` | `/containers/:id/stop` | Conditional | Stop a running container |
+| `POST` | `/containers/:id/restart` | Conditional | Restart a container |
+| `DELETE` | `/containers/:id` | Conditional | Remove a container |
+
+### GET /containers
+
+```json
+{
+  "success": true,
+  "containers": [
+    {
+      "Id": "abc123...",
+      "Names": ["/plex"],
+      "Image": "lscr.io/linuxserver/plex:latest",
+      "State": "running",
+      "Status": "Up 3 days",
+      "Ports": "32400/tcp"
+    }
+  ],
+  "docker": { "status": "connected", "message": "CLI-based Docker access" }
+}
+```
+
+---
+
+## Ports
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/ports/check` | None | List all host ports currently in use by Docker |
+| `GET` | `/ports/available` | None | Find next available port (`?start=8000&end=9000`) |
+
+### GET /ports/check
+
+```json
+{ "success": true, "usedPorts": [8080, 8084, 32400, 8096], "source": "cli" }
+```
+
+### GET /ports/available
+
+```json
+{ "success": true, "availablePort": 8085 }
+```
+
+---
+
+## Health
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/health` | None | Comprehensive health check with Docker, platform, and config status |
+
+Returns `200` when healthy, `503` when degraded or in error state. The response includes Docker connection status, platform info, environment validation, CORS config, and troubleshooting guidance.
+
+---
+
+## Enhanced Mount Manager
+
+These endpoints manage cloud storage providers for containers (experimental).
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/enhanced-mount/:containerId/status` | Conditional | Mount status for a container |
+| `GET` | `/enhanced-mount/:containerId/providers` | Conditional | List available storage providers |
+| `GET` | `/enhanced-mount/:containerId/costs` | Conditional | Estimated storage costs |
+| `GET` | `/enhanced-mount/:containerId/performance` | Conditional | Provider performance metrics |
+| `POST` | `/enhanced-mount/:containerId/providers/:provider/enable` | Conditional | Enable a storage provider |
+| `POST` | `/enhanced-mount/:containerId/providers/:provider/disable` | Conditional | Disable a storage provider |
+| `POST` | `/enhanced-mount/:containerId/auth/start` | Conditional | Start OAuth flow for a provider |
+| `POST` | `/enhanced-mount/:containerId/auth/complete` | Conditional | Complete OAuth flow |
+| `POST` | `/enhanced-mount/:containerId/auth/api-key` | Conditional | Authenticate via API key |
+| `POST` | `/enhanced-mount/:containerId/auth/test` | Conditional | Test provider authentication |
+
+---
+
+## Error Format
+
+All errors return `{ "error": "...", "details": "..." }`. Status codes: `400` bad request, `401` not authenticated, `403` forbidden, `404` not found, `500` server error, `503` Docker unavailable.

--- a/wiki/docs/guides/cli-bridge.md
+++ b/wiki/docs/guides/cli-bridge.md
@@ -1,0 +1,235 @@
+# CLI Bridge Architecture
+
+The CLI Bridge is the layer that connects the HomelabARR CE web dashboard to the library of Docker Compose templates. Understanding it helps when troubleshooting deployments or adding custom applications.
+
+## What the CLI Bridge Does
+
+The backend server starts a `CLIBridge` instance on boot. It:
+
+1. Reads YAML templates from the `apps/` directory
+2. Parses each template into a structured catalog (name, ports, env vars, volumes, labels)
+3. Serves the catalog to the web frontend via the `/applications` API
+4. At deploy time, loads the chosen template, injects user config, and runs `docker compose up -d`
+
+If the CLI Bridge fails to initialize (missing `apps/` directory), the server falls back to a basic template mode with limited functionality.
+
+## The `CLI_BRIDGE_HOST_PATH` Variable
+
+The bridge needs to know where the HomelabARR repository lives on disk.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CLI_BRIDGE_HOST_PATH` | Current working directory | Path to the root of the HomelabARR CLI repo |
+
+In Docker deployments, mount the CLI repo and set this variable:
+
+```yaml
+volumes:
+  - /opt/homelabarr:/opt/homelabarr
+environment:
+  - CLI_BRIDGE_HOST_PATH=/opt/homelabarr
+```
+
+## Directory Structure
+
+```
+/opt/homelabarr/
+  apps/
+    addons/
+      organizr.yml
+      heimdall.yml
+    ai-tools/
+      ollama.yml
+    backup/
+      duplicati.yml
+    coding/
+      code-server.yml
+    downloadclients/
+      qbittorrent.yml
+      sabnzbd.yml
+      deluge.yml
+      nzbget.yml
+    encoder/
+      tdarr.yml
+    kasmworkspace/
+      kasm.yml
+    mediamanager/
+      radarr.yml
+      sonarr.yml
+      prowlarr.yml
+      bazarr.yml
+      lidarr.yml
+      readarr.yml
+    mediaserver/
+      plex.yml
+      jellyfin.yml
+      emby.yml
+    monitoring/
+      tautulli.yml
+    request/
+      overseerr.yml
+    selfhosted/
+      ...
+    share/
+      ...
+    system/
+      portainer.yml
+      pihole.yml
+  traefik/
+    docker-compose.yml
+    install.sh
+  scripts/
+    ...
+```
+
+Only these category directories are scanned: `addons`, `ai-tools`, `backup`, `coding`, `downloadclients`, `encoder`, `kasmworkspace`, `mediamanager`, `mediaserver`, `monitoring`, `request`, `selfhosted`, `share`, `system`. Other directories are ignored to prevent duplicates.
+
+## Template Format
+
+Each YAML file is a standard Docker Compose file. The CLI Bridge parses the first service definition to extract metadata. Here is an annotated example:
+
+```yaml
+version: "3"
+services:
+  radarr:
+    image: ${RADARRIMAGE}
+    container_name: radarr
+    restart: ${RESTARTAPP}
+    networks:
+      - ${DOCKERNETWORK}
+    security_opt:
+      - ${SECURITYOPS}:${SECURITYOPSSET}
+    ports:
+      - 7878:7878
+    environment:
+      - PUID=${ID}
+      - PGID=${ID}
+      - TZ=${TZ}
+      - UMASK=${UMASK}
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:radarr
+      - TP_THEME=${RADARRTHEME}
+    volumes:
+      - ${APPFOLDER}/radarr:/config
+      - /mnt/unionfs:/mnt/unionfs
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)
+      - traefik.http.routers.radarr.tls=true
+      - traefik.http.routers.radarr.tls.certresolver=letsencrypt
+      - traefik.http.services.radarr.loadbalancer.server.port=7878
+      - dockupdater.enable=true
+
+networks:
+  proxy:
+    external: true
+```
+
+The bridge extracts:
+
+- **id**: `mediamanager-radarr` (category + filename)
+- **image**: value of `image` field
+- **ports**: parsed from the `ports` array
+- **environment**: parsed from the `environment` array
+- **volumes**: the `volumes` array
+- **labels**: the `labels` array
+- **requiresTraefik**: `true` if any label contains `traefik.enable=true`
+- **requiresAuthelia**: `true` if any label references `authelia` or `chain-authelia`
+
+## How Deployment Works
+
+```
+User clicks Deploy
+       |
+       v
+POST /deploy { appId, config, mode }
+       |
+       v
+Backend loads YAML template from apps/<category>/<app>.yml
+       |
+       v
+Applies deployment mode transformations
+       |
+       v
+Injects environment variables (user config + defaults)
+       |
+       v
+Writes temporary compose file (for local mode)
+       |
+       v
+Runs: docker compose -f <file> up -d
+       |
+       v
+Streams stdout/stderr to client via SSE
+       |
+       v
+Returns deployment result
+```
+
+## Deployment Modes in Detail
+
+### Standard / Local Mode
+
+The bridge rewrites the compose file before deploying:
+
+1. **Removes external networks** -- deletes any `networks` block with `external: true`
+2. **Strips Traefik labels** -- removes all labels containing `traefik` or `dockupdater`
+3. **Removes security_opt** -- strips security options that may reference unavailable configs
+4. **Sets `DOCKERNETWORK=bridge`** -- uses the default Docker bridge network
+
+The rewritten file is saved as `<app>-local.yml`, deployed, then deleted.
+
+### Traefik Mode
+
+Deploys the original template as-is with:
+
+- `DOCKERNETWORK=proxy` -- connects the container to the Traefik proxy network
+- Ensures Traefik is running (starts it if not)
+- Traefik labels in the template handle routing, SSL, and domain configuration
+
+### Authelia Mode
+
+Same as Traefik mode, plus:
+
+- Ensures Authelia is running alongside Traefik
+- Templates with `chain-authelia` labels get automatic SSO/MFA protection
+
+## Environment Variables
+
+The bridge injects these defaults before every deployment. User-provided values override them.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ID` | `1000` | UID/GID for container processes |
+| `TZ` | `UTC` | Timezone |
+| `UMASK` | `002` | File permission mask |
+| `RESTARTAPP` | `unless-stopped` | Container restart policy |
+| `DOCKERNETWORK` | `proxy` or `bridge` | Network based on deployment mode |
+| `DOMAIN` | `localhost` | Base domain for Traefik routing |
+| `APPFOLDER` | `/opt/appdata` | Root path for persistent app data |
+| `SECURITYOPS` | `no-new-privileges` | Docker security option |
+| `PORTBLOCK` | (empty) | Optional port restriction |
+
+Image variables like `PLEXIMAGE`, `RADARRIMAGE`, etc. default to the latest LinuxServer.io images. Theme variables like `RADARRTHEME` default to `dark`.
+
+## Adding Custom Templates
+
+To add a new application to the catalog:
+
+1. Create a YAML file in the appropriate category directory:
+   ```
+   apps/selfhosted/my-app.yml
+   ```
+
+2. Follow the standard Docker Compose format with at least one service defined under `services:`.
+
+3. Use the environment variable placeholders (`${APPFOLDER}`, `${TZ}`, `${ID}`, etc.) so the bridge can inject user configuration.
+
+4. Add Traefik labels if you want reverse proxy support. Without them, the app will only work in Local mode.
+
+5. Restart the server or click the refresh button in the dashboard. The new app appears automatically in the catalog.
+
+!!! tip "Test in Local mode first"
+    Deploy your custom template in Local/Standard mode before adding Traefik labels. This confirms the container runs correctly before introducing proxy complexity.
+
+!!! warning "Category must be in the allow-list"
+    The bridge only scans the 14 known category directories. If you create a new category folder, it will be ignored. Place custom apps in `selfhosted/` or another existing category.

--- a/wiki/docs/guides/web-dashboard.md
+++ b/wiki/docs/guides/web-dashboard.md
@@ -1,0 +1,125 @@
+# Web Dashboard Guide
+
+The HomelabARR CE web dashboard gives you a visual interface to browse, deploy, and manage 100+ self-hosted applications without touching the command line.
+
+## Accessing the Dashboard
+
+Open your browser and navigate to:
+
+```
+http://<your-server-ip>:8084
+```
+
+Replace `<your-server-ip>` with the IP or hostname of the machine running HomelabARR CE.
+
+## Logging In
+
+On first launch, a default admin account is created automatically.
+
+| Field    | Value   |
+|----------|---------|
+| Username | `admin` |
+| Password | `admin` |
+
+!!! warning "Change the default password immediately"
+    After your first login, go to **User Settings** and change the default password. Passwords must be at least 6 characters.
+
+If authentication is disabled via the `AUTH_ENABLED` environment variable, you can use the dashboard without logging in.
+
+## Browsing the App Catalog
+
+The dashboard organizes applications into category tabs along the top:
+
+- **Deployed Apps** -- containers currently running on your system
+- **Media** -- media servers (Plex, Jellyfin, Emby)
+- **Downloads** -- download clients (qBittorrent, SABnzbd, Deluge, NZBGet)
+- **Management** -- media managers (Radarr, Sonarr, Prowlarr, Bazarr, Lidarr, Readarr)
+- **Requests** -- request tools (Overseerr)
+- **Monitoring** -- monitoring and stats (Tautulli)
+- **Self-Hosted** -- general self-hosted apps
+- **AI Tools** -- AI/ML applications
+- **System** -- system utilities (Portainer, Pi-hole)
+- **All Apps** -- every app in one view
+- **Leaderboard** -- community deployment stats
+
+Each app card shows the application name, description, Docker image, and an icon. Use the **search bar** at the top to filter by name across all categories.
+
+## Deploying an App
+
+1. **Pick an app.** Click any app card to open the deploy modal.
+
+2. **Configure.** The modal shows fields pulled from the app's YAML template:
+    - **Environment variables** -- pre-filled with defaults (timezone, user ID, app data folder). Edit as needed.
+    - **Ports** -- host-to-container port mappings. The dashboard checks for conflicts automatically.
+    - **Volumes** -- persistent storage paths, defaulting to `/opt/appdata/<app>`.
+
+3. **Choose a deployment mode:**
+
+    | Mode | What it does |
+    |------|-------------|
+    | **Local / Standard** | Direct port access on the host, no reverse proxy. Best for testing. |
+    | **Traefik** | Deploys behind Traefik with automatic SSL and domain routing. Production-ready. |
+    | **Traefik + Authelia** | Adds multi-factor authentication on top of Traefik. Maximum security. |
+
+4. **Deploy.** Click the deploy button. The backend loads the YAML template, injects your configuration, writes a temporary compose file, and runs `docker compose up -d`.
+
+5. **Watch progress.** A real-time progress modal opens, streaming deployment output via Server-Sent Events (SSE). You will see Docker pulling images, creating networks, and starting containers live.
+
+!!! tip "Deployment IDs"
+    Each deployment gets a unique ID. You can use this to track status via the API at `/deployments/<id>/status` if the modal closes.
+
+## Container Management
+
+Switch to the **Deployed Apps** tab to see all running containers. Each container card shows:
+
+- Container name, image, and current state (running, stopped, exited)
+- Uptime and status text
+- Port mappings
+
+### Actions
+
+| Button    | What it does |
+|-----------|-------------|
+| **Start** | Starts a stopped container |
+| **Stop**  | Gracefully stops a running container |
+| **Restart** | Stops and restarts the container |
+| **Remove** | Removes the container (optionally with volumes) |
+| **Logs**  | Opens a log viewer showing recent container output |
+
+!!! info "Stats on demand"
+    Container CPU, memory, and network stats are available but not loaded by default to keep the dashboard fast. Add `?stats=true` to the containers API call or use the stats button if present.
+
+### Viewing Logs
+
+Click **Logs** on any container to open the log viewer. Logs are fetched in real time from the Docker daemon. By default the last 100 lines are returned. Use this as your first troubleshooting step when a deployment fails or an app misbehaves.
+
+## User Settings
+
+Click your username in the top-right corner to access the user menu:
+
+- **Change Password** -- enter your current password and a new one (minimum 6 characters)
+- **Manage Sessions** -- view active sessions, revoke sessions from other devices
+- **Logout** -- end your current session
+
+Admins can also access user management to create new accounts or view all users.
+
+## Port Manager
+
+The dashboard includes a built-in port manager accessible from the toolbar. It queries Docker for all ports currently in use and can find the next available port in a given range. Use this before deploying to avoid port conflicts.
+
+## Tips
+
+!!! tip "Use Local Mode for testing"
+    Local/Standard mode strips Traefik labels and external networks, so apps work immediately on `localhost:<port>` without any proxy setup. Switch to Traefik mode when you are ready for production.
+
+!!! tip "Check container logs first"
+    If a deploy finishes but the app is not reachable, check the container logs. Common issues: missing environment variables, port conflicts, or permission errors on volume mounts.
+
+!!! tip "Search is your friend"
+    With 100+ apps, use the search bar instead of scrolling through categories. It searches across app names and descriptions.
+
+!!! tip "Theme toggle"
+    Use the theme toggle in the top bar to switch between light and dark mode. The default theme for all deployed apps is dark.
+
+!!! tip "Refresh the catalog"
+    If you add new YAML templates to the `apps/` directory, click the refresh button to reload the catalog without restarting the server.

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -163,6 +163,7 @@ nav:
       - Quick Start: guides/quick-start.md
       - Linux Installation: install/linux-installation.md
       - Local Mode: install/local-mode.md
+      - Web Dashboard: guides/web-dashboard.md
       - Migration: install/migration.md
   - Setup & Configuration:
       - Authelia: install/authelia.md
@@ -175,6 +176,8 @@ nav:
   - Developer Documentation:
       - Contributing: guides/contributing.md
       - Architecture Overview: guides/architecture.md
+      - CLI Bridge: guides/cli-bridge.md
+      - API Reference: guides/api-reference.md
       - CLI Development: guides/cli-development.md
       - YAML Cleanup Tool: guides/yaml-cleanup-tool.md
   - Commands:


### PR DESCRIPTION
## Summary (PR 2 of 3 — Wiki Overhaul)

### 3 new documentation pages

- **Web Dashboard** (`guides/web-dashboard.md`) — End-user guide: login, app catalog, deploy modal, container management, logs, settings
- **API Reference** (`guides/api-reference.md`) — Every REST endpoint from server/index.js: auth, apps, deploy, containers, ports, health, mount manager
- **CLI Bridge** (`guides/cli-bridge.md`) — How templates flow from `apps/` to the GUI, deployment modes, adding custom templates

### Nav updates
- Web Dashboard added to Getting Started
- API Reference + CLI Bridge added to Developer Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)