### PR TITLE
fix(wiki): stale reference cleanup — docker compose syntax, license badges, dead links

### DIFF
--- a/wiki/docs/apps/addons/a-train.md
+++ b/wiki/docs/apps/addons/a-train.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/autoscan.md
+++ b/wiki/docs/apps/addons/autoscan.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/cloud.md
+++ b/wiki/docs/apps/addons/cloud.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/cloudcmd.md
+++ b/wiki/docs/apps/addons/cloudcmd.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/cloudflare-ddns.md
+++ b/wiki/docs/apps/addons/cloudflare-ddns.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/dashmachine.md
+++ b/wiki/docs/apps/addons/dashmachine.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/diun.md
+++ b/wiki/docs/apps/addons/diun.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/dozzle.md
+++ b/wiki/docs/apps/addons/dozzle.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/flaresolverr.md
+++ b/wiki/docs/apps/addons/flaresolverr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/heimdall.md
+++ b/wiki/docs/apps/addons/heimdall.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/kitana.md
+++ b/wiki/docs/apps/addons/kitana.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/librespeed.md
+++ b/wiki/docs/apps/addons/librespeed.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/netdata.md
+++ b/wiki/docs/apps/addons/netdata.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/notifiarr.md
+++ b/wiki/docs/apps/addons/notifiarr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/remmina.md
+++ b/wiki/docs/apps/addons/remmina.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/speedtest.md
+++ b/wiki/docs/apps/addons/speedtest.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/tauticord.md
+++ b/wiki/docs/apps/addons/tauticord.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/addons/vnstat.md
+++ b/wiki/docs/apps/addons/vnstat.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/apps.md
+++ b/wiki/docs/apps/apps.md
@@ -35,7 +35,7 @@ HomelabARR CE supports 100+ self-hosted applications across multiple categories.
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 
@@ -103,7 +103,7 @@ docker compose -f qbittorrent-local-template.yml --env-file .env up -d
 
 ```bash
 # Install HomelabARR CE
-sudo wget -qO- https://git.io/J3GDc | sudo bash
+# See Quick Start guide for installation: https://smashingtags.github.io/homelabarr-ce/guides/quick-start/
 
 # Launch interface
 sudo homelabarr -i

--- a/wiki/docs/apps/backup/backup.md
+++ b/wiki/docs/apps/backup/backup.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/backup/duplicati.md
+++ b/wiki/docs/apps/backup/duplicati.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/backup/restic.md
+++ b/wiki/docs/apps/backup/restic.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/backup/rsnapshot.md
+++ b/wiki/docs/apps/backup/rsnapshot.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/coding/cloud9.md
+++ b/wiki/docs/apps/coding/cloud9.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/coding/code-server.md
+++ b/wiki/docs/apps/coding/code-server.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/davos.md
+++ b/wiki/docs/apps/downloadclients/davos.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/deluge.md
+++ b/wiki/docs/apps/downloadclients/deluge.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/filezilla.md
+++ b/wiki/docs/apps/downloadclients/filezilla.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/jackett.md
+++ b/wiki/docs/apps/downloadclients/jackett.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/jdownloader2.md
+++ b/wiki/docs/apps/downloadclients/jdownloader2.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/nzbget.md
+++ b/wiki/docs/apps/downloadclients/nzbget.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/nzbhydra.md
+++ b/wiki/docs/apps/downloadclients/nzbhydra.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/rutorrent.md
+++ b/wiki/docs/apps/downloadclients/rutorrent.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/sabnzbd.md
+++ b/wiki/docs/apps/downloadclients/sabnzbd.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/downloadclients/youtubedl-material.md
+++ b/wiki/docs/apps/downloadclients/youtubedl-material.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/encoder/handbrake.md
+++ b/wiki/docs/apps/encoder/handbrake.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/encoder/tdarr.md
+++ b/wiki/docs/apps/encoder/tdarr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/kasmworkspace/kasmdesktop.md
+++ b/wiki/docs/apps/kasmworkspace/kasmdesktop.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/bazarr.md
+++ b/wiki/docs/apps/mediamanager/bazarr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/calibre-web.md
+++ b/wiki/docs/apps/mediamanager/calibre-web.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/embystats.md
+++ b/wiki/docs/apps/mediamanager/embystats.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/lazylibrarian.md
+++ b/wiki/docs/apps/mediamanager/lazylibrarian.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/lidarr.md
+++ b/wiki/docs/apps/mediamanager/lidarr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/plex-utills.md
+++ b/wiki/docs/apps/mediamanager/plex-utills.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/prowlarr.md
+++ b/wiki/docs/apps/mediamanager/prowlarr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/readarr.md
+++ b/wiki/docs/apps/mediamanager/readarr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/sonarr.md
+++ b/wiki/docs/apps/mediamanager/sonarr.md
@@ -316,9 +316,9 @@ docker start sonarr
 ### Manual Backup Before Upgrade
 ```bash
 docker exec sonarr cp /config/sonarr.db /config/sonarr.db.v3backup
-docker-compose down
+docker compose down
 # Update image tag to v4
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Custom Scripts

--- a/wiki/docs/apps/mediamanager/tautulli.md
+++ b/wiki/docs/apps/mediamanager/tautulli.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/traktarr.md
+++ b/wiki/docs/apps/mediamanager/traktarr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediamanager/xteve.md
+++ b/wiki/docs/apps/mediamanager/xteve.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediaserver/emby.md
+++ b/wiki/docs/apps/mediaserver/emby.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediaserver/jellyfin.md
+++ b/wiki/docs/apps/mediaserver/jellyfin.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/mediaserver/mstream.md
+++ b/wiki/docs/apps/mediaserver/mstream.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/request/conreq.md
+++ b/wiki/docs/apps/request/conreq.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/request/petio.md
+++ b/wiki/docs/apps/request/petio.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/alltube.md
+++ b/wiki/docs/apps/selfhosted/alltube.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/bitwarden.md
+++ b/wiki/docs/apps/selfhosted/bitwarden.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/bliss.md
+++ b/wiki/docs/apps/selfhosted/bliss.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/changedetection.md
+++ b/wiki/docs/apps/selfhosted/changedetection.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/cloudbeaver.md
+++ b/wiki/docs/apps/selfhosted/cloudbeaver.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/comixed.md
+++ b/wiki/docs/apps/selfhosted/comixed.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/crewlink.md
+++ b/wiki/docs/apps/selfhosted/crewlink.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/freshrss.md
+++ b/wiki/docs/apps/selfhosted/freshrss.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/gotify.md
+++ b/wiki/docs/apps/selfhosted/gotify.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/homeassistant.md
+++ b/wiki/docs/apps/selfhosted/homeassistant.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/iobroker.md
+++ b/wiki/docs/apps/selfhosted/iobroker.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/joplin-server.md
+++ b/wiki/docs/apps/selfhosted/joplin-server.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/moviematch.md
+++ b/wiki/docs/apps/selfhosted/moviematch.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/netbox.md
+++ b/wiki/docs/apps/selfhosted/netbox.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/nowshowing.md
+++ b/wiki/docs/apps/selfhosted/nowshowing.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/organizr.md
+++ b/wiki/docs/apps/selfhosted/organizr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/pihole.md
+++ b/wiki/docs/apps/selfhosted/pihole.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/recipes.md
+++ b/wiki/docs/apps/selfhosted/recipes.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/share/filerun.md
+++ b/wiki/docs/apps/selfhosted/share/filerun.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/share/nextcloud.md
+++ b/wiki/docs/apps/selfhosted/share/nextcloud.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/share/projectsend.md
+++ b/wiki/docs/apps/selfhosted/share/projectsend.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/snapdrop.md
+++ b/wiki/docs/apps/selfhosted/snapdrop.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/teamspeak.md
+++ b/wiki/docs/apps/selfhosted/teamspeak.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/unifi-controller.md
+++ b/wiki/docs/apps/selfhosted/unifi-controller.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/whoogle.md
+++ b/wiki/docs/apps/selfhosted/whoogle.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/wireguard.md
+++ b/wiki/docs/apps/selfhosted/wireguard.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/selfhosted/xbvr.md
+++ b/wiki/docs/apps/selfhosted/xbvr.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/system/dockupdater.md
+++ b/wiki/docs/apps/system/dockupdater.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/system/endlessh.md
+++ b/wiki/docs/apps/system/endlessh.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/system/mount-enhanced.md
+++ b/wiki/docs/apps/system/mount-enhanced.md
@@ -271,7 +271,7 @@ docker stop homelabarr_mount_enhanced
 sudo cp -r /opt/appdata/mount-backup/* /opt/appdata/mount/
 
 # Start original container
-docker-compose -f /opt/homelabarr/apps/system/mount.yml up -d
+docker compose -f /opt/homelabarr/apps/system/mount.yml up -d
 ```
 
 ## Troubleshooting

--- a/wiki/docs/apps/system/mount.md
+++ b/wiki/docs/apps/system/mount.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/system/rclone-gui.md
+++ b/wiki/docs/apps/system/rclone-gui.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/system/statping.md
+++ b/wiki/docs/apps/system/statping.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/apps/system/wiki.md
+++ b/wiki/docs/apps/system/wiki.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/guides/architecture.md
+++ b/wiki/docs/guides/architecture.md
@@ -70,7 +70,7 @@ graph TB
 - **Request Management**: Overseerr, Petio
 - **Monitoring**: Tautulli, Netdata, Uptime Kuma
 - **Backup**: Duplicati, Restic
-- **Storage Management**: SnapRAID integration (v2.0)
+- **Storage Management**: SnapRAID integration (Professional Edition)
 
 ### Local Mode Components
 
@@ -110,7 +110,7 @@ graph TB
 └── overseerr/      # Request management
 ```
 
-### SnapRAID Integration (v2.0)
+### SnapRAID Integration (Professional Edition)
 ```mermaid
 graph TB
     Frontend[Dashboard UI] --> API[SnapRAID API]
@@ -129,7 +129,7 @@ graph TB
     Frontend -.polling.-> API
 ```
 
-**SnapRAID v2.0 Features:**
+**SnapRAID Features (Professional Edition):**
 - **Drop-in Integration**: Seamless API compatibility
 - **Real-time Progress**: Operation status and progress tracking
 - **Cross-platform Support**: Windows development, Linux deployment
@@ -275,7 +275,7 @@ Targets:
 ### Planned Enhancements
 - **Kubernetes Support**: Container orchestration expansion
 - **CLI Modernization**: Go/Bubble Tea interface
-- **API Integration**: RESTful management interface (✅ SnapRAID v2.0)
+- **API Integration**: RESTful management interface (Professional Edition)
 - **Observability**: Enhanced monitoring and tracing
 - **Storage Management**: Advanced SnapRAID configuration UI
 - **WebSocket Updates**: Real-time operation updates

--- a/wiki/docs/guides/contributing.md
+++ b/wiki/docs/guides/contributing.md
@@ -173,17 +173,17 @@ Common issues and solutions.
 
 ```bash
 # Validate YAML syntax
-docker-compose -f apps/category/new-app.yml --env-file .env.test config
+docker compose -f apps/category/new-app.yml --env-file .env.test config
 
 # Test deployment
-docker-compose -f apps/category/new-app.yml --env-file .env.test up -d
+docker compose -f apps/category/new-app.yml --env-file .env.test up -d
 
 # Verify functionality
 docker ps --filter "name=new-app"
 docker logs new-app
 
 # Clean up
-docker-compose -f apps/category/new-app.yml --env-file .env.test down
+docker compose -f apps/category/new-app.yml --env-file .env.test down
 ```
 
 ## Documentation Development
@@ -303,7 +303,7 @@ test: add container validation tests
 .claude/scripts/clean-yaml-files.sh --validate-only
 
 # Manual YAML check if needed
-find apps/ -name "*.yml" -exec docker-compose -f {} config \;
+find apps/ -name "*.yml" -exec docker compose -f {} config \;
 
 # Script validation
 shellcheck scripts/*.sh

--- a/wiki/docs/guides/deployment-guide.md
+++ b/wiki/docs/guides/deployment-guide.md
@@ -81,16 +81,16 @@ volumes:
 
 ```bash
 # 1. Validate YAML syntax
-docker-compose -f apps/path/container.yml --env-file .env.test config
+docker compose -f apps/path/container.yml --env-file .env.test config
 
 # 2. Deploy container  
-docker-compose -f apps/path/container.yml --env-file .env.test up -d
+docker compose -f apps/path/container.yml --env-file .env.test up -d
 
 # 3. Verify deployment
 docker ps --filter "name=container_name"
 
 # 4. Clean up
-docker-compose -f apps/path/container.yml --env-file .env.test down
+docker compose -f apps/path/container.yml --env-file .env.test down
 ```
 
 ## 📋 Environment Configuration

--- a/wiki/docs/guides/deployment-summary.md
+++ b/wiki/docs/guides/deployment-summary.md
@@ -143,7 +143,7 @@ homelabarr/
 
 ```bash
 # Quick installation
-sudo wget -qO- https://git.io/J3GDc | sudo bash
+# See Quick Start guide for installation: https://smashingtags.github.io/homelabarr-ce/guides/quick-start/
 
 # Or manual installation
 git clone https://github.com/smashingtags/homelabarr-ce.git

--- a/wiki/docs/guides/faq.md
+++ b/wiki/docs/guides/faq.md
@@ -116,8 +116,8 @@ Common issues:
 ### How do I update applications?
 ```bash
 # Update single application
-docker-compose -f apps/category/app.yml pull
-docker-compose -f apps/category/app.yml up -d
+docker compose -f apps/category/app.yml pull
+docker compose -f apps/category/app.yml up -d
 
 # Update all containers
 docker images | grep -v REPOSITORY | awk '{print $1":"$2}' | xargs -L1 docker pull
@@ -280,8 +280,8 @@ cd homelabarr-ce
 git pull origin master
 
 # Update containers
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 ### How often should I update?

--- a/wiki/docs/guides/yaml-cleanup-tool.md
+++ b/wiki/docs/guides/yaml-cleanup-tool.md
@@ -258,13 +258,13 @@ After running the cleanup tool:
 
 ```bash
 # Test Docker Compose parsing
-docker-compose -f apps/mediaserver/plex.yml config
+docker compose -f apps/mediaserver/plex.yml config
 
 # Validate YAML syntax
 yamllint apps/mediaserver/plex.yml
 
 # Test actual deployment
-docker-compose -f apps/mediaserver/plex.yml up --dry-run
+docker compose -f apps/mediaserver/plex.yml up --dry-run
 ```
 
 ## Integration with Development Workflow

--- a/wiki/docs/install/authelia.md
+++ b/wiki/docs/install/authelia.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/install/cf-companion.md
+++ b/wiki/docs/install/cf-companion.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/install/linux-installation.md
+++ b/wiki/docs/install/linux-installation.md
@@ -161,7 +161,7 @@ After running the installer, you'll see the main menu:
 ```bash
 # Check Docker installation
 docker --version
-docker-compose --version
+docker compose version
 
 # Verify containers are running
 docker ps
@@ -388,8 +388,8 @@ After installation, consider these security measures:
    sudo apt update && sudo apt upgrade
 
    # Update Docker containers
-   docker-compose pull
-   docker-compose up -d
+   docker compose pull
+   docker compose up -d
    ```
 
 ## Next Steps

--- a/wiki/docs/install/local-mode.md
+++ b/wiki/docs/install/local-mode.md
@@ -497,7 +497,7 @@ This allows testing Local Mode while maintaining Full Mode production services.
 
 2. **Install HomelabARR CE Full Mode**:
    ```bash
-   sudo wget -qO- https://git.io/J3GDc | sudo bash
+   # See Quick Start guide for installation: https://smashingtags.github.io/homelabarr-ce/guides/quick-start/
    ```
 
 3. **Deploy through HomelabARR CE interface**:

--- a/wiki/docs/install/migration.md
+++ b/wiki/docs/install/migration.md
@@ -9,7 +9,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/lxc/lxc.md
+++ b/wiki/docs/lxc/lxc.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/releases/RELEASE-NOTES.md
+++ b/wiki/docs/releases/RELEASE-NOTES.md
@@ -58,13 +58,13 @@ These 8 services are fully tested and guaranteed to work perfectly:
 
 # Or deploy any bulk converted app
 cd apps/local-mode-apps
-docker-compose -f SERVICE.yml --env-file ../.config/.env up -d
+docker compose -f SERVICE.yml --env-file ../.config/.env up -d
 
 # Popular examples:
-docker-compose -f nextcloud.yml --env-file ../.config/.env up -d      # Cloud storage
-docker-compose -f pihole.yml --env-file ../.config/.env up -d         # Ad blocking
-docker-compose -f heimdall.yml --env-file ../.config/.env up -d       # Dashboard
-docker-compose -f code-server.yml --env-file ../.config/.env up -d    # VS Code
+docker compose -f nextcloud.yml --env-file ../.config/.env up -d      # Cloud storage
+docker compose -f pihole.yml --env-file ../.config/.env up -d         # Ad blocking
+docker compose -f heimdall.yml --env-file ../.config/.env up -d       # Dashboard
+docker compose -f code-server.yml --env-file ../.config/.env up -d    # VS Code
 ```
 
 ## 🎯 Deployment Options

--- a/wiki/docs/scripts/maintenance.md
+++ b/wiki/docs/scripts/maintenance.md
@@ -193,10 +193,10 @@ echo "Updating all containers..."
 
 # Pull latest images
 cd /opt/homelabarr
-find apps/ -name "*.yml" -exec docker-compose -f {} pull \;
+find apps/ -name "*.yml" -exec docker compose -f {} pull \;
 
 # Restart containers with new images
-find apps/ -name "*.yml" -exec docker-compose -f {} up -d \;
+find apps/ -name "*.yml" -exec docker compose -f {} up -d \;
 
 # Clean up old images
 docker image prune -f
@@ -217,8 +217,8 @@ if [ -z "$APP_PATH" ]; then
 fi
 
 echo "Updating $APP_PATH..."
-docker-compose -f "$APP_PATH" pull
-docker-compose -f "$APP_PATH" up -d
+docker compose -f "$APP_PATH" pull
+docker compose -f "$APP_PATH" up -d
 echo "Update complete!"
 ```
 

--- a/wiki/docs/scripts/scripts.md
+++ b/wiki/docs/scripts/scripts.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 

--- a/wiki/docs/scripts/yaml-cleanup.md
+++ b/wiki/docs/scripts/yaml-cleanup.md
@@ -275,7 +275,7 @@ git checkout apps/mediaserver/plex.yml
 ### Validation After Cleanup
 ```bash
 # Test Docker Compose parsing
-docker-compose -f apps/mediaserver/plex.yml config
+docker compose -f apps/mediaserver/plex.yml config
 
 # Validate with yamllint (if installed)
 yamllint apps/mediaserver/plex.yml

--- a/wiki/docs/tunnel/cf_tunnel.md
+++ b/wiki/docs/tunnel/cf_tunnel.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/v/release/smashingtags/homelabarr-ce?include_prereleases&label=Latest%20Release&logo=github" alt="Latest Official Release on GitHub">
     </a>
     <a href="https://github.com/smashingtags/homelabarr-ce/blob/main/LICENSE">
-        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=gnu" alt="GNU General Public License">
+        <img src="https://img.shields.io/github/license/smashingtags/homelabarr-ce?label=License&logo=mit" alt="MIT License">
     </a>
 </p>
 


### PR DESCRIPTION
## Summary (PR 3 of 3 — Wiki Overhaul)

- `docker-compose` (hyphenated command) → `docker compose` across all docs
- GNU license badges → MIT (repo is MIT licensed)
- Dead git.io shortlinks replaced with wiki quick-start URL
- SnapRAID v2.0 references updated to indicate Professional Edition
- 106 files touched, 129 lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)