### PR TITLE
fix(wiki): CORS_ORIGIN required — login fails without it

### DIFF
--- a/wiki/docs/guides/quick-start.md
+++ b/wiki/docs/guides/quick-start.md
@@ -24,13 +24,17 @@ The fastest way to get HomelabARR CE running. Four commands, no domain required.
 # Download the compose file
 curl -o homelabarr.yml https://raw.githubusercontent.com/smashingtags/homelabarr-ce/main/homelabarr.yml
 
-# Generate a JWT secret and detect your Docker group ID
+# Set required environment variables
 export JWT_SECRET=$(openssl rand -base64 32)
 export DOCKER_GID=$(getent group docker | cut -d: -f3)
+export CORS_ORIGIN=http://$(hostname -I | awk '{print $1}'):8084
 
 # Start HomelabARR CE
 docker compose -f homelabarr.yml up -d
 ```
+
+!!! warning "CORS_ORIGIN is required"
+    The backend rejects browser requests unless `CORS_ORIGIN` matches the URL you use to access the dashboard. If you access it at `http://192.168.1.50:8084`, set `CORS_ORIGIN=http://192.168.1.50:8084`. Without this, login and all API calls will fail with a 500 error.
 
 Once the containers are up:
 
@@ -47,6 +51,7 @@ Once the containers are up:
     ```bash
     echo "JWT_SECRET=$(openssl rand -base64 32)" > .env
     echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+    echo "CORS_ORIGIN=http://$(hostname -I | awk '{print $1}'):8084" >> .env
     ```
 
 !!! note "Running in a Proxmox LXC?"

--- a/wiki/docs/install/linux-installation.md
+++ b/wiki/docs/install/linux-installation.md
@@ -24,7 +24,10 @@ export JWT_SECRET=$(openssl rand -base64 32)
 # 3. Detect your Docker socket group ID
 export DOCKER_GID=$(getent group docker | cut -d: -f3)
 
-# 4. Start the stack
+# 4. Set CORS origin to your server's IP
+export CORS_ORIGIN=http://$(hostname -I | awk '{print $1}'):8084
+
+# 5. Start the stack
 docker compose -f homelabarr.yml up -d
 ```
 
@@ -34,6 +37,7 @@ docker compose -f homelabarr.yml up -d
 |----------|---------|------------|
 | `JWT_SECRET` | Signs auth tokens for the dashboard | `openssl rand -base64 32` |
 | `DOCKER_GID` | Grants the container access to the Docker socket | `getent group docker \| cut -d: -f3` |
+| `CORS_ORIGIN` | **Required.** URL you use to access the dashboard | `http://your-server-ip:8084` |
 | `CLI_BRIDGE_HOST_PATH` | (Optional) Host path for CLI bridge scripts | Defaults to internal path if unset |
 
 ### Accessing the Dashboard
@@ -47,6 +51,7 @@ From the dashboard you can browse 157+ app templates and deploy them with one cl
     ```bash
     echo "JWT_SECRET=$(openssl rand -base64 32)" > .env
     echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+    echo "CORS_ORIGIN=http://$(hostname -I | awk '{print $1}'):8084" >> .env
     ```
 
 !!! note "For Traefik + domain setup, see Method 2 below"


### PR DESCRIPTION
Found during install validation on Proxmox 183. Without CORS_ORIGIN, the backend rejects all browser requests with a 500. Added to all install docs.