### PR TITLE
fix(wiki): clean URLs — /install/migration/ instead of .html

### DIFF
--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -17,7 +17,7 @@
 
 # Project information
 site_name: HomelabARR Wiki
-use_directory_urls: false
+use_directory_urls: true
 site_url: ""
 site_author: HomelabARR CE
 site_description: Documentation for HomelabARR Community Edition — free, open-source Docker container management


### PR DESCRIPTION
One-line change: use_directory_urls: true