### PR TITLE
feat: one-line CLI installer (like dockserver)

### DIFF
--- a/install-remote.sh
+++ b/install-remote.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#####################################
+# HomelabARR CE — One-Line Installer
+# Usage: sudo wget -qO- https://raw.githubusercontent.com/smashingtags/homelabarr-ce/main/install-remote.sh | sudo bash
+#####################################
+
+set -e
+
+REPO="https://github.com/smashingtags/homelabarr-ce.git"
+INSTALL_DIR="/opt/homelabarr"
+BIN_NAME="homelabarr-cli"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "    🚀 HomelabARR CE — One-Line Installer"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Check root
+if [[ $EUID -ne 0 ]]; then
+  echo "⛔ This script must be run as root (use sudo)"
+  exit 1
+fi
+
+# Install git if missing
+if ! command -v git &>/dev/null; then
+  echo "📦 Installing git..."
+  apt-get update -qq && apt-get install -y -qq git >/dev/null 2>&1
+fi
+
+# Clone or update repo
+if [[ -d "$INSTALL_DIR" ]]; then
+  echo "📂 Updating existing installation at $INSTALL_DIR..."
+  cd "$INSTALL_DIR" && git pull --ff-only 2>/dev/null || true
+else
+  echo "📥 Cloning HomelabARR CE to $INSTALL_DIR..."
+  git clone "$REPO" "$INSTALL_DIR"
+fi
+
+cd "$INSTALL_DIR"
+
+# Make all scripts executable
+echo "🔧 Setting permissions..."
+find . -name "*.sh" -exec chmod +x {} \;
+chmod +x .installer/homelabber 2>/dev/null || true
+
+# Install the CLI command system-wide
+echo "🔗 Installing $BIN_NAME command..."
+cp .installer/homelabber /usr/local/bin/$BIN_NAME 2>/dev/null || true
+chmod +x /usr/local/bin/$BIN_NAME 2>/dev/null || true
+
+# Also install to /bin for compatibility
+cp .installer/homelabber /bin/$BIN_NAME 2>/dev/null || true
+chmod +x /bin/$BIN_NAME 2>/dev/null || true
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "    ✅ HomelabARR CE installed successfully!"
+echo ""
+echo "    Run the installer:  sudo homelabarr-cli -i"
+echo "    Or start directly:  cd $INSTALL_DIR && sudo ./install.sh"
+echo ""
+echo "    Wiki: https://smashingtags.github.io/homelabarr-ce/"
+echo "    Discord: https://discord.gg/Pc7mXX786x"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""

--- a/wiki/docs/guides/quick-start.md
+++ b/wiki/docs/guides/quick-start.md
@@ -109,7 +109,21 @@ docker compose -f homelabarr.yml up -d
 
 An interactive terminal-based installer with a menu system. You choose what to install — nothing is forced.
 
-### Installation
+### One-Line Install
+
+```bash
+sudo wget -qO- https://raw.githubusercontent.com/smashingtags/homelabarr-ce/main/install-remote.sh | sudo bash
+```
+
+Then open the menu:
+
+```bash
+sudo homelabarr-cli -i
+```
+
+That's it. The script clones the repo to `/opt/homelabarr`, sets permissions, and installs the `homelabarr-cli` command.
+
+### Manual Install (alternative)
 
 ```bash
 git clone https://github.com/smashingtags/homelabarr-ce.git


### PR DESCRIPTION
## One-line install

```bash
sudo wget -qO- https://raw.githubusercontent.com/smashingtags/homelabarr-ce/main/install-remote.sh | sudo bash
sudo homelabarr-cli -i
```

Clones to /opt/homelabarr, sets all permissions, installs homelabarr-cli globally. This is the CLI menu path — no web GUI, no CORS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)