### PR TITLE
fix(ci): suppress empty security audit PR comment

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -411,7 +411,7 @@ jobs:
           retention-days: 90
 
       - name: Comment PR with security summary
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && (needs.shell-security-analysis.result == 'success' || needs.compose-security-validation.result == 'success' || needs.docker-vulnerability-scan.result == 'success')
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
Only post the security summary comment when at least one scan ran. No more boilerplate on docs-only PRs.