### PR TITLE
fix(ci): update Trivy, ShellCheck, docker-compose versions

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           echo "Installing ShellCheck and other security tools..."
           # Download ShellCheck binary directly
-          SHELLCHECK_VERSION="0.9.0"
+          SHELLCHECK_VERSION="0.10.0"
           wget -q https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz
           tar -xf shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz
           mkdir -p $HOME/.local/bin
@@ -164,7 +164,7 @@ jobs:
           if ! command -v docker-compose &> /dev/null; then
             echo "Docker Compose not found, downloading..."
             # Download docker-compose binary
-            COMPOSE_VERSION="2.23.3"
+            COMPOSE_VERSION="2.36.2"
             wget -q https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-x86_64 -O $HOME/.local/bin/docker-compose
             chmod +x $HOME/.local/bin/docker-compose
             export PATH="$HOME/.local/bin:$PATH"
@@ -242,7 +242,7 @@ jobs:
         run: |
           echo "Installing Trivy vulnerability scanner..."
           # Download trivy binary directly without requiring sudo
-          TRIVY_VERSION="0.48.0"
+          TRIVY_VERSION="0.69.3"
           wget -q https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz
           tar zxf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz
           chmod +x trivy


### PR DESCRIPTION
Trivy 0.48.0 release was removed, causing docker-vulnerability-scan to fail. Updated all tools to latest.