### PR TITLE
fix(ci): bump all actions to Node 24 support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
         run: mkdocs build --config-file wiki/mkdocs.yml --site-dir ../site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -139,7 +139,7 @@ jobs:
           fi
 
       - name: Upload shell analysis results
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: shell-security-analysis-${{ github.sha }}
@@ -220,7 +220,7 @@ jobs:
           }
 
       - name: Upload compose validation results
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: compose-security-validation-${{ github.sha }}
@@ -356,7 +356,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload vulnerability reports
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: docker-vulnerability-scan-${{ github.sha }}
@@ -372,7 +372,7 @@ jobs:
     if: always()
     steps:
       - name: Download all security artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v4
         with:
           path: security-reports
 
@@ -404,7 +404,7 @@ jobs:
           cat security-summary.md
 
       - name: Upload security compliance summary
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: security-compliance-summary-${{ github.sha }}
           path: security-summary.md


### PR DESCRIPTION
Node 20 deprecated June 2, 2026. Bumped dorny/paths-filter v3→v4, upload-pages-artifact v3→v4.