### PR TITLE
fix(wiki): set site_url to wiki.homelabarr.com

### DIFF
--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -18,7 +18,7 @@
 # Project information
 site_name: HomelabARR Wiki
 use_directory_urls: true
-site_url: ""
+site_url: "https://wiki.homelabarr.com"
 site_author: HomelabARR CE
 site_description: Documentation for HomelabARR Community Edition — free, open-source Docker container management
 


### PR DESCRIPTION
Custom domain configured on GitHub Pages. MkDocs needs the site_url for correct sitemap and canonical URLs.