### PR TITLE
fix: remove Traefik gate, fix installer errors, scope permissions

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
   packages: read
   security-events: write
-  pull-requests: write
+  pull-requests: read
   actions: read
 
 concurrency:
@@ -368,6 +368,9 @@ jobs:
   # Security compliance summary
   security-compliance-summary:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
     needs: [shell-security-analysis, compose-security-validation, docker-vulnerability-scan]
     if: always()
     steps:

--- a/apps/.installer/ubuntu.sh
+++ b/apps/.installer/ubuntu.sh
@@ -13,14 +13,18 @@
 # NO CODE MIRRORING IS ALLOWED      #
 #####################################
 appstartup() {
+# Traefik check removed — apps work without it (local/standard mode)
+# If Traefik is not running, apps deploy with direct port access instead of domain routing
 ds=$(docker ps -a --format '{{.Names}}' | sed '/^$/d' | grep -x 'traefik')
 if [[ ${ds} == "" ]];then
 printf "
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-⛔  You deploy Traefik before you can deploy any Apps
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⚠️  Traefik is not running — apps will deploy in local mode
+    Access via http://your-ip:PORT instead of https://app.domain
+    To set up Traefik, use Option 1 from the main menu
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 "
-sleep 30 && exit
+sleep 5
 fi
 
 if [[ $EUID -ne 0 ]];then

--- a/install-remote.sh
+++ b/install-remote.sh
@@ -31,7 +31,11 @@ fi
 # Clone or update repo
 if [[ -d "$INSTALL_DIR" ]]; then
   echo "📂 Updating existing installation at $INSTALL_DIR..."
-  cd "$INSTALL_DIR" && git pull --ff-only 2>/dev/null || true
+  cd "$INSTALL_DIR"
+  if ! git pull --ff-only 2>&1; then
+    echo "⚠️  Could not fast-forward update. You may have local changes."
+    echo "    Run 'cd $INSTALL_DIR && git stash && git pull' to resolve."
+  fi
 else
   echo "📥 Cloning HomelabARR CE to $INSTALL_DIR..."
   git clone "$REPO" "$INSTALL_DIR"
@@ -46,12 +50,17 @@ chmod +x .installer/homelabber 2>/dev/null || true
 
 # Install the CLI command system-wide
 echo "🔗 Installing $BIN_NAME command..."
-cp .installer/homelabber /usr/local/bin/$BIN_NAME 2>/dev/null || true
-chmod +x /usr/local/bin/$BIN_NAME 2>/dev/null || true
-
-# Also install to /bin for compatibility
-cp .installer/homelabber /bin/$BIN_NAME 2>/dev/null || true
-chmod +x /bin/$BIN_NAME 2>/dev/null || true
+if ! cp .installer/homelabber /usr/local/bin/$BIN_NAME 2>/dev/null; then
+  if ! cp .installer/homelabber /bin/$BIN_NAME 2>/dev/null; then
+    echo "⚠️  Could not install $BIN_NAME to PATH. Run manually: cd $INSTALL_DIR && sudo ./install.sh"
+  else
+    chmod +x /bin/$BIN_NAME
+  fi
+else
+  chmod +x /usr/local/bin/$BIN_NAME
+  # Also install to /bin for compatibility
+  cp .installer/homelabber /bin/$BIN_NAME 2>/dev/null && chmod +x /bin/$BIN_NAME 2>/dev/null
+fi
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Addresses Codex review findings:

- **Traefik no longer required for CLI app deployment** — the old code blocked all app installs if Traefik wasn't running. Now shows a warning and proceeds in local mode. Apps work fine without Traefik.
- **install-remote.sh** reports failures instead of swallowing them with `|| true`
- **security-audit** pull-requests:write scoped to compliance job only