### PR TITLE
fix: add domain field help text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -356,9 +356,10 @@ export default function App() {
         label: 'Domain',
         type: 'text' as const,
         required: false,
-        placeholder: 'yourdomain.com (only needed for Traefik mode)',
+        placeholder: 'yourdomain.com — no https:// needed',
         defaultValue: '',
         trafikOnly: true,
+        helpText: 'Just the domain (e.g. mjashley.com). Apps will be accessible at appname.yourdomain.com',
       },
     ];
 

--- a/src/components/DeployModal.tsx
+++ b/src/components/DeployModal.tsx
@@ -224,6 +224,9 @@ export function DeployModal({
                     className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                   />
                 )}
+                {field.helpText && (
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{field.helpText}</p>
+                )}
               </div>
             ))}
           </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export interface ConfigField {
   defaultValue?: string;
   advanced?: boolean;
   trafikOnly?: boolean;
+  helpText?: string;
 }
 
 export interface DeploymentMode {


### PR DESCRIPTION
Shows hint below domain field: no https://, just the domain name, apps accessible at appname.yourdomain.com