### PR TITLE
fix: community apps use the same deploy modal as native apps

### DIFF
--- a/docs/COMMUNITY-APP-STORE-SPEC.md
+++ b/docs/COMMUNITY-APP-STORE-SPEC.md
@@ -119,3 +119,6 @@ Like Unraid's Community Applications. Decentralized template repos maintained by
 - Trending/popularity
 - User reviews
 - Spotlight/featured apps
+
+## Credits & Attribution
+The Community App Store uses data from the [Unraid Community Applications](https://github.com/Squidly271/AppFeed) project, maintained by [Squidly271](https://github.com/Squidly271) and the Unraid community. We are grateful for their work in curating the largest self-hosted application catalog in the homelab ecosystem. Docker images are provided by their respective authors and maintainers. HomelabARR is not affiliated with or endorsed by Lime Technology (Unraid).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -261,13 +261,17 @@ export default function App() {
     }
   }, [activeCategory]);
 
-  const handleCommunityInstall = useCallback(async (app: CommunityApp) => {
-    try {
-      await installCommunityApp(app.Name, {}, { type: 'local' });
-      success('Deployed', `${app.Name} is being deployed`);
-    } catch (err) {
-      showError('Deploy Failed', `Could not deploy ${app.Name}`);
-    }
+  const handleCommunityInstall = useCallback((app: CommunityApp) => {
+    const template: AppTemplate = {
+      id: `community-${app.Name}`,
+      name: app.Name,
+      description: app.Overview || '',
+      category: 'selfhosted' as any,
+      logo: Package,
+      deploymentModes: ['local', 'traefik', 'authelia'],
+      _communityApp: app,
+    } as any;
+    setSelectedApp(template);
   }, []);
 
   useEffect(() => {
@@ -377,6 +381,19 @@ export default function App() {
     }
 
     setSelectedApp(null);
+
+    // Community app — use community install endpoint
+    const communityApp = (selectedApp as any)?._communityApp as CommunityApp | undefined;
+    if (communityApp) {
+      try {
+        await installCommunityApp(communityApp.Name, config, mode);
+        success('Deployed', `${communityApp.Name} is being deployed`);
+      } catch (err) {
+        showError('Deploy Failed', `Could not deploy ${communityApp.Name}`);
+      }
+      return;
+    }
+
     await handleDeploy(appId, config, mode);
   };
 

--- a/src/components/CommunityStore.tsx
+++ b/src/components/CommunityStore.tsx
@@ -277,6 +277,21 @@ export function CommunityStore({ apps, categories: _categories, onInstall, loadi
             </Button>
           </div>
         )}
+
+        {/* Credits */}
+        <div className="mt-8 pt-6 border-t border-white/10 text-center text-xs text-zinc-500">
+          <p>
+            Community app data provided by the{' '}
+            <a href="https://github.com/Squidly271/AppFeed" className="text-indigo-400 hover:underline" target="_blank" rel="noopener noreferrer">
+              Unraid Community Applications
+            </a>{' '}
+            project, maintained by{' '}
+            <a href="https://github.com/Squidly271" className="text-indigo-400 hover:underline" target="_blank" rel="noopener noreferrer">
+              Squidly271
+            </a>{' '}
+            and the Unraid community. Docker images are provided by their respective authors.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/wiki/docs/guides/faq.md
+++ b/wiki/docs/guides/faq.md
@@ -36,6 +36,10 @@ No. HomelabARR runs as Docker containers and deploys Docker containers. Docker i
 
 CE (Community Edition) is 100% free and open source under the MIT license. There's also a [Professional Edition](../pe/overview.md) with NAS management features — that one's paid.
 
+### Where do the Community Store apps come from?
+
+The Community Store aggregates app data from the [Unraid Community Applications](https://github.com/Squidly271/AppFeed) project, maintained by [Squidly271](https://github.com/Squidly271) and the Unraid community. This gives you access to 3,000+ Docker apps. HomelabARR auto-generates deployment configs from the feed data — you don't need Unraid to use them. Docker images are provided by their respective authors. HomelabARR is not affiliated with or endorsed by Lime Technology (Unraid).
+
 ---
 
 ## After Installing


### PR DESCRIPTION
Community app Install button now opens the DeployModal with mode selection (Standard/Traefik/Authelia) instead of firing the API directly.