### PR TITLE
fix: default tab to Deployed Apps

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ export default function App() {
   const [selectedApp, setSelectedApp] = useState<AppTemplate | null>(null);
   const [deployedApps, setDeployedApps] = useState<DeployedApp[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [activeCategory, setActiveCategory] = useState<TabId>('all-apps');
+  const [activeCategory, setActiveCategory] = useState<TabId>('deployed');
   const [sortField, setSortField] = useState<'name' | 'status' | 'deployedAt' | 'uptime'>('name');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [catalogSort, setCatalogSort] = useState<'asc' | 'desc'>('asc');


### PR DESCRIPTION
All Apps rendered 3,000 cards on load. Default to Deployed Apps instead.