### PR TITLE
feat: clean up community catalog — 792 apps rescued, upstream feed cut

### DIFF
--- a/docs/COMMUNITY-APP-STORE-SPEC.md
+++ b/docs/COMMUNITY-APP-STORE-SPEC.md
@@ -37,25 +37,25 @@ Like Unraid's Community Applications. Decentralized template repos maintained by
   ```
 - Official templates repo (`smashingtags/homelabarr-templates`) is one of many repos
 
-### Central Feed
+### Central Catalog (Current State)
+- The catalog is fully independent — no upstream Unraid feed, no database, no nightly refresh from an external source
+- All 2,900+ apps exist as pre-generated Docker Compose YAMLs in the templates repo under `community/<category>/<app>.yml`
+- A JSON index (`community-apps.json`) provides metadata for browsing and search
+- New apps are submitted via PR to `smashingtags/homelabarr-templates`
+- Clicking **Refresh** in the UI runs `git pull` on the templates directory
+- The catalog was originally seeded from Unraid Community Applications data, then cleaned up and frozen as static files
+
+### Central Feed (Future)
 - We maintain a feed file (like Unraid's `applicationFeed.json`) that indexes all registered repos
 - Feed is hosted on GitHub, fetched/cached by CE backend
 - Repos register by submitting a PR to add their repo URL to a registry file
 - Feed is rebuilt periodically (GitHub Action) by scanning all registered repos
 
-### Unraid Feed Ingestion
-- Import Unraid's 3,439 apps as a compatibility layer
-- Auto-generate HomelabARR YAML from Unraid XML templates
-- Translation: Unraid `[IP]:[PORT:xxx]` → our `${DOMAIN}`, `/mnt/user/appdata/` → `${APPFOLDER}/`
-- Filter out Unraid plugins (not Docker containers)
-- Mark as "Unraid Community" source
-
 ### Backend
-- `GET /community/apps` — returns aggregated feed (cached)
+- `GET /community/apps` — returns catalog from JSON index (cached in memory)
 - `GET /community/repos` — returns repository list
-- `POST /community/install/:appId` — generates YAML from feed data and deploys
-- Feed cache refreshed daily or on-demand
-- Translation layer converts Unraid config format → Docker Compose YAML on the fly
+- `POST /community/install/:appId` — deploys from pre-generated YAML
+- Refresh endpoint runs `git pull` on templates directory
 
 ### Frontend
 - Community Store tab (separate from the bundled catalog)
@@ -77,36 +77,19 @@ Like Unraid's Community Applications. Decentralized template repos maintained by
 - GPU badge (if applicable)
 - Install button → same deploy modal
 
-## Data Sources
-
-### Unraid Feed (already downloaded)
-- `/tmp/applicationFeed.json` — 23MB, 3,439 apps
-- Fields: Name, Repository (Docker image), Config (ports/volumes/envs), Overview, Icon, CategoryList, WebUI, Project, Support
-- Categories: AI, Backup, Cloud, Crypto, Downloaders, Drivers, Game Servers, Home Automation, Language, Media Apps, Media Servers, Network, Other, Plugins, Productivity, Security, Tools
-
-### Translation Rules (Unraid → HomelabARR)
-- `Repository` → `image` in compose
-- `Config[Type=Port]` → `ports` mapping
-- `Config[Type=Path]` → `volumes`, rewrite `/mnt/user/appdata/` to `${APPFOLDER}/`
-- `Config[Type=Variable]` → `environment` vars
-- `Network=bridge` → our default
-- `Network=host` → `network_mode: host`
-- `Privileged=true` → `privileged: true`
-- `WebUI` → extract port for Traefik label generation
-- Skip entries with no `Repository` (plugins, not containers)
-
 ## Phases
 
-### Phase 1 (current PR #109): Foundation
+### Phase 1 (done): Foundation
 - community-apps.json index for our 116 official templates
 - Official/Community badges, author display, tag search
 - Community tab
 
-### Phase 2: Unraid Feed Ingestion
-- Backend fetches and caches Unraid feed
-- Translation layer generates Docker Compose on the fly
-- Community Store view with 3,000+ apps
+### Phase 2 (done): Independent Catalog
+- 2,900+ apps as pre-generated Docker Compose YAMLs in the templates repo
+- JSON index for browsing and search
 - Category sidebar, search, sort, pagination
+- No database, no external feed dependency
+- New apps added via PRs to the templates repo
 
 ### Phase 3: Decentralized Repos
 - Repository registration system
@@ -121,4 +104,4 @@ Like Unraid's Community Applications. Decentralized template repos maintained by
 - Spotlight/featured apps
 
 ## Credits & Attribution
-The Community App Store uses data from the [Unraid Community Applications](https://github.com/Squidly271/AppFeed) project, maintained by [Squidly271](https://github.com/Squidly271) and the Unraid community. We are grateful for their work in curating the largest self-hosted application catalog in the homelab ecosystem. Docker images are provided by their respective authors and maintainers. HomelabARR is not affiliated with or endorsed by Lime Technology (Unraid).
+The Community App Store was originally seeded with data from the [Unraid Community Applications](https://github.com/Squidly271/AppFeed) project, maintained by [Squidly271](https://github.com/Squidly271) and the Unraid community. We are grateful for their work in curating the largest self-hosted application catalog in the homelab ecosystem. The catalog is now maintained independently in the HomelabARR templates repo. Docker images are provided by their respective authors and maintainers. HomelabARR is not affiliated with or endorsed by Lime Technology (Unraid).

--- a/server/generate-community-templates.js
+++ b/server/generate-community-templates.js
@@ -49,6 +49,36 @@ const CATEGORY_MAP = {
   'Tools / Utilities': 'tools',
 };
 
+const KEYWORD_CATEGORIES = [
+  { pattern: /\b(plex|jellyfin|emby|tautulli|navidrome|kodi|subsonic|airsonic|funkwhale|mstream)\b/i, category: 'media-servers' },
+  { pattern: /\b(sonarr|radarr|lidarr|bazarr|prowlarr|jackett|readarr|whisparr|recyclarr|kometa|overseerr|jellyseerr|ombi|petio|traktarr|autobrr|flaresolverr)\b/i, category: 'media-management' },
+  { pattern: /\b(immich|photoprism|lychee|pigallery|librephotos|photoview|photostructure)\b/i, category: 'media-management' },
+  { pattern: /\b(torrent|nzb|qbit|transmission|deluge|sabnzbd|usenet|rtorrent|rutorrent|flood|aria2)\b/i, category: 'downloads' },
+  { pattern: /\b(backup|duplicati|restic|borg|rsync|duplicacy|urbackup|bacula|veeam|kopia)\b/i, category: 'backup' },
+  { pattern: /\b(vpn|wireguard|openvpn|tailscale|zerotier|gluetun|wg-easy)\b/i, category: 'networking' },
+  { pattern: /\b(dns|pihole|adguard|nginx|caddy|traefik|proxy|haproxy|swag|duckdns|cloudflared|unbound)\b/i, category: 'networking' },
+  { pattern: /\b(monitor|grafana|prometheus|uptime|netdata|zabbix|checkmk|healthcheck|smokeping|speedtest|vnstat|tauticord|scrutiny)\b/i, category: 'monitoring' },
+  { pattern: /\b(minecraft|valheim|satisfactory|terraria|factorio|palworld|enshrouded|7.?days|ark\b|rust\b|csgo|counter.?strike)\b/i, category: 'game-servers' },
+  { pattern: /\b(home.?assist|hass|zigbee|mqtt|node.?red|z.?wave|frigate|scrypted|esphome|tasmota)\b/i, category: 'home-automation' },
+  { pattern: /\b(nextcloud|seafile|syncthing|owncloud|filerun|filebrowser)\b/i, category: 'cloud' },
+  { pattern: /\b(password|vault|auth|2fa|ldap|keycloak|authelia|crowdsec|fail2ban|bitwarden)\b/i, category: 'security' },
+  { pattern: /\b(ollama|llm|whisper|stable.?diff|comfyui|gpt|openai|langchain|text.?gen|kobold|localai)\b/i, category: 'ai' },
+  { pattern: /\b(wiki|bookstack|outline|paperless|invoice|docspell|stirling|mealie|recipes|tandoor|grocy)\b/i, category: 'productivity' },
+  { pattern: /\b(git|gitea|gitlab|forgejo|jenkins|drone|woodpecker|code.?server|coder)\b/i, category: 'tools' },
+  { pattern: /\b(docker|portainer|watchtower|dozzle|yacht|container)\b/i, category: 'tools' },
+  { pattern: /\b(postgres|mysql|mariadb|redis|mongo|influxdb|sqlite|cockroach)\b/i, category: 'tools' },
+  { pattern: /\b(mail|smtp|imap|roundcube|mailu|stalwart|postal|maddy)\b/i, category: 'productivity' },
+  { pattern: /\b(wordpress|ghost|hugo|jekyll|blog|cms)\b/i, category: 'productivity' },
+];
+
+function inferCategory(name, overview) {
+  const text = `${name || ''} ${overview || ''}`;
+  for (const { pattern, category } of KEYWORD_CATEGORIES) {
+    if (pattern.test(text)) return category;
+  }
+  return null;
+}
+
 function sanitizeName(name) {
   return (name || 'unknown').toLowerCase().replace(/[^a-z0-9_-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
 }
@@ -91,7 +121,13 @@ for (const app of apps) {
   const appConfigs = configs.all(app.id);
   const categories = appCats.all(app.id).map(r => r.description);
   const primaryCategory = categories[0] || 'Other';
-  const dirName = CATEGORY_MAP[primaryCategory] || sanitizeName(primaryCategory);
+  let dirName = CATEGORY_MAP[primaryCategory] || sanitizeName(primaryCategory);
+
+  // If mapped to 'other', try keyword inference
+  if (dirName === 'other') {
+    const inferred = inferCategory(app.name, app.overview);
+    if (inferred) dirName = inferred;
+  }
 
   // Build the feed-format object that template-generator expects
   const feedApp = {

--- a/wiki/docs/guides/community-store.md
+++ b/wiki/docs/guides/community-store.md
@@ -1,30 +1,30 @@
 # Community App Store
 
-HomelabARR CE includes a community app store with 2,900+ Docker apps sourced from the [Unraid Community Applications](https://github.com/Squidly271/AppFeed) catalog.
+HomelabARR CE includes a community app store with 2,900+ Docker apps originally sourced from the [Unraid Community Applications](https://github.com/Squidly271/AppFeed) catalog, now maintained independently as pre-generated templates.
 
 ---
 
 ## How It Works
 
-The community store is powered by a local SQLite database that ships with the [templates repo](https://github.com/smashingtags/homelabarr-templates). When you click the **Community** tab, you're querying a local database — fast and works offline.
+The community store is a JSON index (`community-apps.json`) plus pre-generated Docker Compose YAMLs, all stored in the [templates repo](https://github.com/smashingtags/homelabarr-templates). No database, no external feed — everything is static files served from disk.
 
 ### Data Flow
 
-1. A [GitHub Action](https://github.com/smashingtags/homelabarr-templates/actions) refreshes the database daily at 6 AM UTC
-2. When you click **Refresh** in the Community Store, the backend runs `git pull` on the templates directory to fetch the latest database
-3. The CE backend queries the SQLite database and serves results to the frontend
-4. When you click **Install**, the backend auto-generates a Docker Compose file from the app's config and deploys it
+1. The templates repo contains pre-generated YAMLs at `community/<category>/<app>.yml`
+2. When you click the **Community** tab, the backend reads the JSON index and serves results
+3. When you click **Refresh**, the backend runs `git pull` on the templates directory to fetch the latest catalog
+4. When you click **Install**, the backend deploys from the pre-generated YAML — no on-the-fly conversion
 
-### What Gets Translated
+### Template Format
 
-Unraid templates use a different format than HomelabARR. The backend handles the translation automatically:
+All community templates are standard Docker Compose YAMLs with HomelabARR conventions:
 
-| Unraid Format | HomelabARR Format |
-|--------------|-------------------|
-| XML template with `[IP]:[PORT:xxx]` | Docker Compose YAML |
-| `/mnt/user/appdata/` paths | `/opt/appdata/` paths |
-| Unraid-specific env vars | Standard Docker env vars |
-| `Network=bridge` / `Network=host` | `proxy` network or `network_mode: host` |
+| Convention | Example |
+|-----------|---------|
+| Appdata paths | `/opt/appdata/<app>/` |
+| Standard Docker env vars | `PUID`, `PGID`, `TZ` |
+| Network modes | `proxy` network or `network_mode: host` |
+| Traefik labels | Auto-generated from WebUI port |
 
 You don't need Unraid to use community apps. They're standard Docker containers.
 
@@ -32,49 +32,30 @@ You don't need Unraid to use community apps. They're standard Docker containers.
 
 ## Setup
 
-If you followed the [Quick Start](quick-start.md), the templates repo (including the community database) is already cloned at `/opt/homelabarr/templates`. The community store works out of the box.
-
-### Database location
-
-The backend looks for the database in these locations (first match wins):
-
-1. `COMMUNITY_DB_PATH` environment variable
-2. `data/unraid-ca.db` inside the app directory
-3. `server/data/unraid-ca.db` inside the app directory
-4. `/app/data/unraid-ca.db` (Docker container default)
-
-If you mounted the templates repo at `/opt/homelabarr/templates`, the database is at `/opt/homelabarr/templates/data/unraid-ca.db`. Make sure this path is accessible to the backend container — either via the existing templates volume mount or a separate mount:
-
-```yaml
-backend:
-  volumes:
-    - /opt/homelabarr/templates/data/unraid-ca.db:/app/data/unraid-ca.db:ro
-```
+If you followed the [Quick Start](quick-start.md), the templates repo is already cloned at `/opt/homelabarr/templates`. The community store works out of the box — no database or extra configuration needed.
 
 ---
 
 ## Updating
 
-### Automatic (recommended)
-
-A GitHub Action on the templates repo refreshes the database daily at 6 AM UTC. To get the update:
+### Via the UI (recommended)
 
 1. Click the **Refresh** button in the Community Store (top right, next to sort)
 2. The backend runs `git pull` on the templates directory
-3. The app list reloads with the latest data
+3. The app list reloads with the latest catalog
 
 Only admins can refresh.
 
 ### Manual
-
-If you prefer to update manually:
 
 ```bash
 cd /opt/homelabarr/templates
 git pull
 ```
 
-The backend picks up the new database automatically.
+### Contributing New Apps
+
+New community apps are submitted via PR to [smashingtags/homelabarr-templates](https://github.com/smashingtags/homelabarr-templates). Add a YAML to the appropriate `community/<category>/` directory and update the index.
 
 ---
 
@@ -106,32 +87,32 @@ Click **Install** on any community app. You'll see the same deploy modal as nati
 2. Click **Deploy**
 3. The app deploys from a pre-generated Docker Compose YAML — no on-the-fly conversion
 
-All 2,900+ community templates are pre-generated and validated against `docker compose config`. The daily refresh regenerates them from the latest feed data. Templates are stored at `community/<category>/<app>.yml` in the templates repo.
+All 2,900+ community templates are pre-generated and validated against `docker compose config`. Templates are stored at `community/<category>/<app>.yml` in the templates repo.
 
 ---
 
 ## Template Validation
 
-Every community template is validated with `docker compose config` during generation:
+Every community template was validated with `docker compose config` during generation:
 
 - **2,816** pass validation (99.75%)
-- **7** fail due to bad data in the upstream Unraid feed (malformed ports, volume names with spaces, undefined named volumes)
-- **21** skipped (no Docker image — Unraid plugins, not containers)
+- **7** fail due to malformed data (bad ports, volume names with spaces, undefined named volumes)
+- **21** skipped (no Docker image)
 
-Failed templates are still generated but may not deploy successfully. These are upstream data quality issues.
+Failed templates are still included but may not deploy successfully.
 
 ---
 
-## Database Stats
+## Catalog Stats
 
 - **2,900+** Docker apps (blacklisted, deprecated, and plugins filtered out)
 - **628** template repositories / authors
 - **15** categories
-- **25,000+** config entries (ports, volumes, env vars)
+- **563** apps in the Other category (down from 1,355 after cleanup)
 - **Full-text search** across names, descriptions, and search terms
 
 ---
 
 ## Credits
 
-Community app data is provided by the [Unraid Community Applications](https://github.com/Squidly271/AppFeed) project, maintained by [Squidly271](https://github.com/Squidly271) and the Unraid community. Docker images are provided by their respective authors. HomelabARR is not affiliated with or endorsed by Lime Technology (Unraid).
+Community app data was originally sourced from the [Unraid Community Applications](https://github.com/Squidly271/AppFeed) project, maintained by [Squidly271](https://github.com/Squidly271) and the Unraid community. The catalog is now maintained independently in the HomelabARR templates repo. Docker images are provided by their respective authors. HomelabARR is not affiliated with or endorsed by Lime Technology (Unraid).


### PR DESCRIPTION
- Keyword inference moved 792 apps from Other into real categories
- Other dropped from 1,355 to 563
- Upstream feed tooling archived to private repo (smashingtags/ur-script-convert)
- Removed from templates repo: tools/, data/, GitHub Action
- Docs updated — no database, no external feed references
- Catalog is fully self-maintained via PRs