### PR TITLE
fix: deduplicate community apps overlapping official templates

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1298,15 +1298,34 @@ app.get('/applications', optionalAuth, async (req, res) => {
       }));
     }
 
-    // Merge community apps into the unified catalog
+    // Merge community apps, skipping duplicates that already exist as official templates
     try {
+      const officialNames = new Set();
+      for (const apps of Object.values(applications)) {
+        for (const app of apps) {
+          officialNames.add(app.name?.toLowerCase());
+        }
+      }
+
       const communityResult = await getCommunityApps({ perPage: 10000 });
       const communityApps = (communityResult.apps || []).map(convertCommunityApp);
+      let dedupSkipped = 0;
       for (const app of communityApps) {
+        const normalizedName = app.name?.toLowerCase().replace(/[^a-z0-9]/g, '');
+        const officialMatch = [...officialNames].some(n =>
+          n && n.replace(/[^a-z0-9]/g, '') === normalizedName
+        );
+        if (officialMatch) {
+          dedupSkipped++;
+          continue;
+        }
         if (!applications[app.category]) {
           applications[app.category] = [];
         }
         applications[app.category].push(app);
+      }
+      if (dedupSkipped > 0) {
+        logger.info(`Unified catalog: skipped ${dedupSkipped} community apps that duplicate official templates`);
       }
     } catch (err) {
       logger.warn('Failed to load community apps for unified catalog:', err.message);


### PR DESCRIPTION
## Summary
- Official and community templates had ~2,486 overlapping apps showing as duplicates in the UI
- Official apps used `category-name` IDs, community used `community-name` IDs — frontend `seenIds` dedup couldn't catch them
- Backend now normalizes names and skips community entries when an official template already exists
- Official templates win (they have Traefik labels, health checks, better configs)

## Test plan
- [ ] Load /applications endpoint, verify totalApps is ~3,500 not ~6,100
- [ ] Check logs for "skipped X community apps that duplicate official templates"
- [ ] Verify no duplicate app cards in UI