### PR TITLE
fix: E2E workflow — add manual dispatch, prevent cancellation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,11 @@ on:
     branches: [dev, staging, main]
   push:
     branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   e2e:


### PR DESCRIPTION
## Summary
- Added `workflow_dispatch` trigger so E2E tests can be run on demand
- Added `concurrency` group with `cancel-in-progress: false` — rapid pushes no longer cancel running E2E tests
- E2E tests have been cancelled on every dev push because new pushes killed in-progress runs

## Test plan
- [ ] Trigger E2E manually after merge via Actions tab