### PR TITLE
fix: E2E timeout + Node 20 deprecation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   e2e:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,11 +26,12 @@ jobs:
 
     name: E2E (${{ matrix.target.name }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@v5
         id: changes
         with:
           filters: |


### PR DESCRIPTION
## Summary
- E2E timeout bumped from 10 to 15 minutes
- Added npm cache to speed up installs
- Bumped actions/checkout v4→v6, actions/setup-node v4→v5 (Node 22)
- Bumped dorny/paths-filter v4→v5 in security audit workflow