### PR TITLE
fix: enable staging E2E target

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,9 +20,8 @@ jobs:
         target:
           - name: dev
             url: https://ce-dev.homelabarr.com
-          # Uncomment when staging is stable:
-          # - name: staging
-          #   url: https://ce-staging.homelabarr.com
+          - name: staging
+            url: https://ce-staging.homelabarr.com
 
     name: E2E (${{ matrix.target.name }})
     steps:


### PR DESCRIPTION
ce-staging.homelabarr.com is now live on its own VM. Enable it in the E2E matrix.