### PR TITLE
fix: deploy progress stream — send clientId in SSE connected event

### DIFF
--- a/server/progress-stream.js
+++ b/server/progress-stream.js
@@ -37,8 +37,9 @@ export class ProgressStreamManager extends EventEmitter {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Headers', 'Cache-Control');
 
-    // Send initial connection event
+    // Send initial connection event with the server-assigned clientId
     this.sendToClient(clientId, 'connected', {
+      clientId,
       message: 'Connected to deployment progress stream',
       timestamp: new Date().toISOString()
     });


### PR DESCRIPTION
Root cause: server-generated clientId wasn't included in the connected event. Frontend generated a different ID, server rejected the subscribe.