### PR TITLE
fix: add minimal top-level permissions to workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,10 @@ name: Generate changelog
 on:
   release:
     types: [ created ]
+
+permissions:
+  contents: read
+
 jobs:
   changelog-wiki:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -20,6 +20,9 @@ env:
   FRONTEND_IMAGE_NAME: homelabarr-frontend
   BACKEND_IMAGE_NAME: homelabarr-backend
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [dev]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     timeout-minutes: 10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds `permissions: contents: read` to 4 workflows missing top-level permissions:
- changelog.yml
- docker-build-push.yml
- e2e-tests.yml
- stale.yml

Job-level permissions still elevate where needed (packages:write for GHCR, issues:write for stale, etc.).

Resolves CodeQL #54.

## Summary by Sourcery

CI:
- Add top-level contents: read permissions to changelog, Docker build/push, E2E tests, and stale issue workflows while keeping elevated permissions at the job level where necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow security configurations by explicitly defining minimal required permissions across automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->