### PR TITLE
fix: resolve 3 npm security vulnerabilities (npm audit fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,9 +1516,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7395,9 +7395,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12045,9 +12045,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
`npm audit fix` resolves all 3 advisories on main:
- **vite** (HIGH: 3 CVEs - path traversal, fs.deny bypass, WebSocket file read)
- **hono** (moderate: 5 CVEs - cookie validation, IPv6 matching, path traversal, middleware bypass)
- **@hono/node-server** (moderate: middleware bypass)

Only `package-lock.json` changed -- no `package.json` updates needed.

## Verification
- `npm audit` after fix: 0 vulnerabilities
- `npm run build` passes (1601 modules, 1.33s, no errors)

The note about "9 vulnerabilities" from the push warning is stale (some count duplicates per CVE). After this merges, the count drops to 0.

## Summary by Sourcery

Resolve all reported npm security advisories by updating lockfile dependencies via npm audit fix.

Bug Fixes:
- Address security vulnerabilities in vite related to path traversal, fs.deny bypass, and WebSocket file read.
- Fix multiple security issues in hono including cookie validation, IPv6 matching, path traversal, and middleware bypass.
- Resolve middleware bypass vulnerability in @hono/node-server by updating its locked version.

Build:
- Regenerate package-lock.json to reflect secure dependency versions without changing package.json.