### PR TITLE
release: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # HomelabARR CE Changelog
 
+## [v2.2.0] - April 14, 2026
+
+### 🐛 Bug Fixes (Backported from Eight.ly fork)
+- **Container delete/stop/restart**: Docker client was never passed to the CLI manager. All container operations now work correctly. ([#146](https://github.com/smashingtags/homelabarr-ce/pull/146))
+- **Docker socket permissions**: Apps that mount `docker.sock` (Portainer, etc.) now get `group_add` injected at deploy time so they can read/write the socket. ([#146](https://github.com/smashingtags/homelabarr-ce/pull/146))
+- **Read-only template volumes**: Temp deploy YAMLs now write to `server/data/` instead of next to the source YAML, so deploys don't fail with EACCES on read-only mounts. ([#146](https://github.com/smashingtags/homelabarr-ce/pull/146))
+- **Deploy progress stream**: SSE `connected` event now includes the server-assigned `clientId`, fixing "Client not found" 500s on subscribe. ([#146](https://github.com/smashingtags/homelabarr-ce/pull/146))
+
+### 🔒 Security
+- **npm vulnerabilities patched**: vite, hono, @hono/node-server bumped to address 9 advisories (3 high, 6 moderate). ([#145](https://github.com/smashingtags/homelabarr-ce/pull/145))
+- **Workflow permissions**: Added explicit `permissions: contents: read` to all workflows missing it. Resolves CodeQL alert. ([#144](https://github.com/smashingtags/homelabarr-ce/pull/144))
+
+### 📚 Documentation
+- **Wiki cleanup**: Removed Professional Edition section; replaced placeholder octopus with optimized v3b WebP at proper sizes. ([#147](https://github.com/smashingtags/homelabarr-ce/pull/147))
+
+---
+
 ## [v2.0.0] - September 2025
 
 ### 🗄️ ARCHIVED COMPONENTS

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homelabarr",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite\" \"node server/index.js\"",


### PR DESCRIPTION
## v2.2.0 — Deploy bug fixes + security patches + wiki cleanup

Bumps version 2.0.1 → 2.2.0. After merge, I'll tag and create the GitHub Release.

### Highlights
- 4 critical deploy bug fixes ported back from the Eight.ly fork (#146)
- 9 npm security advisories resolved (#145)
- Workflow permissions tightened (#144)
- Wiki cleanup: removed Professional Edition, swapped to v3b octopus (#147)
- Repo went public

See CHANGELOG.md for the full rundown.

## Summary by Sourcery

Release version 2.2.0 with documented bug fixes, security updates, and wiki clean-up.

Bug Fixes:
- Fix multiple container lifecycle issues, including passing the Docker client to the CLI manager and resolving deploy progress stream client ID errors.
- Ensure applications using docker.sock receive appropriate group permissions at deploy time and prevent EACCES errors from read-only template volumes by relocating temporary deploy YAMLs.

CI:
- Tighten GitHub Actions workflow permissions by explicitly setting read-only contents access in applicable workflows.

Documentation:
- Update changelog and clean up wiki content, including removing the Professional Edition section and updating artwork assets.

Chores:
- Bump package version from 2.0.1 to 2.2.0 to reflect the new release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container delete, stop, and restart operations
  * Resolved Docker socket permissions for mounted containers
  * Fixed deploy progress event handling to prevent connection errors
  * Improved deploy file handling on read-only mounts

* **Security**
  * Patched npm dependencies for enhanced protection
  * Hardened workflow security policies

* **Documentation**
  * Updated documentation and assets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->