### PR TITLE
docs: remove Pro Edition section + Author → Developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,16 +252,6 @@ Found a vulnerability? Email **michael@mjashley.com** — see [SECURITY.md](SECU
 
 ---
 
-## Want More? Check Out the Pro Edition
-
-CE handles Docker containers. **PE** (Professional Edition) adds storage management — SnapRAID + MergerFS + cache mover + file sharing + system monitoring.
-
-If you've got a bunch of mismatched hard drives and want to turn them into a storage pool without RAID, that's what PE is for.
-
-[See pricing →](https://homelabarr.com#pricing)
-
----
-
 ## Links
 
 | | |
@@ -272,7 +262,7 @@ If you've got a bunch of mismatched hard drives and want to turn them into a sto
 | 💬 **Discord** | [discord.gg/Pc7mXX786x](https://discord.gg/Pc7mXX786x) |
 | 📣 **Reddit** | [r/homelabarr](https://www.reddit.com/r/homelabarr/) |
 | 🏢 **Company** | [imogenlabs.ai](https://imogenlabs.ai) |
-| 👤 **Author** | [mjashley.com](https://mjashley.com) |
+| 👤 **Developer** | [mjashley.com](https://mjashley.com) |
 
 ---
 


### PR DESCRIPTION
- Drop the 'Want More? Check Out the Pro Edition' section (PE is no longer a planned product)
- Rename 'Author' to 'Developer' in the Links table (matches the wiki and homelabarr.com footer)

## Summary by Sourcery

Update README to remove references to the discontinued Pro Edition and align terminology in the links section.

Documentation:
- Remove the Pro Edition marketing section from the README.
- Rename the 'Author' link label to 'Developer' in the README links table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Want More? Check Out the Pro Edition" section, including feature descriptions and pricing information
  * Updated the links section label from "Author" to "Developer"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->