### PR TITLE
ci: bump Playwright workers from 1 to 4

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI ? 'github' : 'html',
   timeout: 30_000,
 


### PR DESCRIPTION
Forcing `workers: 1` in CI makes 19 read-only tests take ~6 minutes in serial.

E2E tests are all observations against the live demo (catalog, modals, icons, dark mode, footer) with no state mutations. Safe to parallelize.

Expected: ~6 min → ~1.5 min on GitHub's 4-core runners.

## Summary by Sourcery

CI:
- Update Playwright CI configuration to use 4 workers instead of 1 when running tests.