### PR TITLE
docs(wiki): flatten nav + move Discord/Discussions to header icons

### DIFF
--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -86,6 +86,9 @@ extra:
     - icon: fontawesome/brands/discord
       link: https://discord.gg/Pc7mXX786x
       name: Discord
+    - icon: fontawesome/solid/comments
+      link: https://github.com/smashingtags/homelabarr-ce/discussions
+      name: GitHub Discussions
     - icon: fontawesome/solid/building
       link: https://imogenlabs.ai
       name: Imogen Labs
@@ -130,10 +133,7 @@ nav:
       - Architecture: guides/architecture.md
       - CLI Bridge: guides/cli-bridge.md
       - Contributing: guides/contributing.md
-  - Community:
-      - Migration Guide: guides/migration.md
-      - Project History: guides/history.md
-      - White-Label & Forking: guides/white-label.md
-      - FAQ & Troubleshooting: guides/faq.md
-      - Discord: https://discord.gg/Pc7mXX786x
-      - GitHub Discussions: https://github.com/smashingtags/homelabarr-ce/discussions
+  - Migration Guide: guides/migration.md
+  - Project History: guides/history.md
+  - White-Label & Forking: guides/white-label.md
+  - FAQ & Troubleshooting: guides/faq.md


### PR DESCRIPTION
## Changes

### Nav structure

**Before:**
- Home
- Getting Started
- Guides
- Developer
- **Community** *(nested section)*
    - Migration Guide
    - Project History
    - White-Label & Forking
    - FAQ & Troubleshooting
    - Discord *(external link)*
    - GitHub Discussions *(external link)*

**After:**
- Home
- Getting Started
- Guides
- Developer
- Migration Guide *(flat)*
- Project History *(flat)*
- White-Label & Forking *(flat)*
- FAQ & Troubleshooting *(flat)*

### Header icons (`extra.social`)

Added GitHub Discussions icon (`fontawesome/solid/comments`) next to the existing GitHub, Discord, Imogen Labs, and Developer icons in the top-right of every page.

Discord was already a social icon — kept it there, removed duplicate from nav.

## Summary by Sourcery

Flatten the wiki navigation by inlining former Community pages and move GitHub Discussions access to a top-level header icon alongside the existing social links.

Enhancements:
- Add a GitHub Discussions social icon in the wiki header and rely on header social links instead of nav entries for Discord and Discussions.

Documentation:
- Expose Migration Guide, Project History, White-Label & Forking, and FAQ & Troubleshooting as top-level wiki nav entries instead of under a nested Community section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation navigation with key guides (Migration Guide, Project History, White-Label & Forking, FAQ & Troubleshooting) now accessible at the top level
  * Added GitHub Discussions as a social link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->