### PR TITLE
docs: fix broken README mascot image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
     <a href="https://github.com/smashingtags/homelabarr-ce">
-      <img src="wiki/docs/img/homelabarr-octopus-v2b.jpg" alt="HomelabARR CE" width="300">
+      <img src="wiki/docs/img/mascot-600.webp" alt="HomelabARR CE" width="300">
     </a>
 </p>
 


### PR DESCRIPTION
## Summary
- README header image was pointing at a file that no longer exists.
- Swap to the current pirate-mascot placeholder.

## Why
Commit a613e0f swapped the octopus logo for the new pirate-mascot placeholder and deleted the old \`wiki/docs/img/octopus-v3b-*.webp\` files. README still referenced \`wiki/docs/img/homelabarr-octopus-v2b.jpg\` which was removed earlier than that. Header image has been broken on GitHub for ~12 hours.

## Test plan
- [ ] Open the PR diff on GitHub — rendered README should show the pirate mascot at the top
- [ ] No other files touched

## Notes
\`wiki/docs/guides/_white-label-audit.md\` still flags the old reference at README:5 — that file is auto-regenerated by the whitelabel-audit workflow, so it'll correct itself on the next run.

## Summary by Sourcery

Documentation:
- Refresh README header image to point at the new pirate mascot graphic so it renders correctly on GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project's mascot image in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->