### PR TITLE
fix: harden users.json loader + DialogDescription a11y

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -33,7 +33,16 @@ export function loadUsers() {
       return [];
     }
     const data = fs.readFileSync(USERS_FILE, 'utf8');
-    return JSON.parse(data);
+    const parsed = JSON.parse(data);
+    // Guard against malformed state (e.g. users.json saved as {} instead of []).
+    // Without this, every downstream call (users.find, users.length) breaks and
+    // the default-admin seeder never runs because `users.length === 0` is false
+    // for non-arrays.
+    if (!Array.isArray(parsed)) {
+      console.warn(`users.json is not an array (got ${typeof parsed}) — ignoring and returning []. File will be rewritten on next save.`);
+      return [];
+    }
+    return parsed;
   } catch (error) {
     console.error('Error loading users:', error);
     return [];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 
 // Tab type encompasses display categories + special views
 type TabId = string; // display category ids, 'deployed', 'all-apps'
@@ -850,6 +850,9 @@ export default function App() {
           <DialogContent className="max-w-6xl max-h-[90vh] overflow-y-auto">
             <DialogHeader>
               <DialogTitle>Enhanced Mount Dashboard</DialogTitle>
+              <DialogDescription className="sr-only">
+                Manage mount points, volumes, and bind mounts for the selected container.
+              </DialogDescription>
             </DialogHeader>
             {selectedEnhancedMount && (
               <EnhancedMountManager

--- a/src/components/ApiKeysModal.tsx
+++ b/src/components/ApiKeysModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { Key, Copy, Check, Trash2, Plus, Loader2, Smartphone, AlertTriangle } from "lucide-react";
 import { useAuth } from "../contexts/AuthContext";
 import { useNotifications } from "../contexts/NotificationContext";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -139,9 +139,9 @@ export function ApiKeysModal({ isOpen, onClose }: ApiKeysModalProps) {
             </div>
           </div>
           <DialogTitle className="text-center text-2xl">API Keys</DialogTitle>
-          <p className="text-center text-sm text-muted-foreground">
+          <DialogDescription className="text-center text-sm text-muted-foreground">
             Generate keys for the HomelabARR mobile app or third-party integrations
-          </p>
+          </DialogDescription>
         </DialogHeader>
 
         {/* New key display */}

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { getContainerLogs } from "../lib/api";
 import { Terminal } from "lucide-react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface LogViewerProps {
@@ -46,6 +46,9 @@ export function LogViewer({ containerId, onClose }: LogViewerProps) {
             <Terminal className="w-5 h-5" />
             Container Logs
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Real-time log output for the selected container.
+          </DialogDescription>
           <label className="flex items-center text-gray-300 text-sm">
             <input
               type="checkbox"

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Lock, User, Eye, EyeOff, Loader2 } from "lucide-react";
 import { useAuth } from "../contexts/AuthContext";
 import { useNotifications } from "../contexts/NotificationContext";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -52,6 +52,9 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
             </div>
           </div>
           <DialogTitle className="text-center text-2xl">Sign In to HomelabARR</DialogTitle>
+          <DialogDescription className="sr-only">
+            Enter your username and password to sign in to the HomelabARR dashboard.
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
## Summary
Two defensive fixes surfaced while debugging today's 401 login failure on ce-demo (`TypeError: users.find is not a function`).

### 1. `server/auth.js` — guard `loadUsers()` against non-array JSON
If `users.json` is ever saved as `{}` (seen in the wild on VM 121 earlier today), every downstream call (`users.find`, `users.length === 0`) misfires — including `initializeAuth()`, which means the default-admin seeder never runs. Now:

```js
const parsed = JSON.parse(data);
if (!Array.isArray(parsed)) {
  console.warn(`users.json is not an array (got ${typeof parsed}) — ignoring and returning []. File will be rewritten on next save.`);
  return [];
}
return parsed;
```

This lets the seeder recover automatically from the malformed state.

### 2. DialogContent accessibility
Radix Dialog warns when `DialogContent` has no `DialogDescription`. Added descriptions to four modals that were missing them:

| File | Treatment |
|------|-----------|
| `src/components/LoginModal.tsx` | `sr-only` description |
| `src/components/LogViewer.tsx` | `sr-only` description |
| `src/App.tsx` (Enhanced Mount modal) | `sr-only` description |
| `src/components/ApiKeysModal.tsx` | Promoted the existing `<p>` helper text to `<DialogDescription>` — preserves visible text, fixes a11y |

`CommandDialog` in `src/components/ui/command.tsx` is shadcn boilerplate, unused anywhere in the app. Left alone — if/when it gets used, it'll need the same treatment (VisuallyHidden wrapper around DialogTitle + DialogDescription).

## Test plan
- [x] `npx tsc --noEmit --project tsconfig.app.json` passes
- [x] `node --check server/auth.js` passes
- [x] Lint on touched files: no new errors (17 pre-existing errors in App.tsx/LogViewer.tsx are out of scope)
- [ ] Smoke: log in to ce-demo — no console warning, login works
- [ ] Smoke: open API Keys, Log Viewer, Enhanced Mount modals — no console warnings

## Out of scope
- The 17 pre-existing lint errors in `src/App.tsx` and `src/components/LogViewer.tsx` (explicit-any, unused-vars, etc.) are untouched.
- Eight.ly is forked from CE and has the same `loadUsers()` — worth cherry-picking this guard there too, but separate PR on separate repo.

## Summary by Sourcery

Harden user authentication configuration loading and improve dialog accessibility across key modals.

Bug Fixes:
- Guard the users.json loader against non-array JSON data to prevent runtime errors and allow default admin seeding to recover from malformed files.

Enhancements:
- Add accessible DialogDescription content to login, log viewer, enhanced mount, and API keys modals to satisfy dialog semantics and improve screen reader support.