### PR TITLE
HLCE-182: revert cosign-installer to v3 (fix red build from #222)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -130,7 +130,7 @@ jobs:
 
     - name: Install cosign
       if: github.event_name != 'pull_request'
-      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
 
     - name: Sign frontend image
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
PR #222 bumped cosign-installer v3->v4.1.2; v4 'cosign verify' fails (signing works), cascading to skip Trivy + fail SARIF upload. Image build/push is fine. Revert to v3 to restore green. Re-bump to v4 later with updated verify flags.