### PR TITLE
HLCE-182: fix cosign verify identity (org migration smashingtags->imogenlabs)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -148,7 +148,7 @@ jobs:
       if: github.event_name != 'pull_request'
       run: |
         cosign verify \
-          --certificate-identity-regexp 'https://github.com/smashingtags/homelabarr-ce/.github/workflows/' \
+          --certificate-identity-regexp 'https://github.com/imogenlabs/homelabarr-ce/.github/workflows/' \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
           ghcr.io/${{ env.NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}@${{ steps.build-frontend.outputs.digest }}
 
@@ -156,7 +156,7 @@ jobs:
       if: github.event_name != 'pull_request'
       run: |
         cosign verify \
-          --certificate-identity-regexp 'https://github.com/smashingtags/homelabarr-ce/.github/workflows/' \
+          --certificate-identity-regexp 'https://github.com/imogenlabs/homelabarr-ce/.github/workflows/' \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
           ghcr.io/${{ env.NAMESPACE }}/${{ env.BACKEND_IMAGE_NAME }}@${{ steps.build-backend.outputs.digest }}
 


### PR DESCRIPTION
Real root cause of the red build: images are signed with the imogenlabs OIDC identity (repo was transferred), but cosign verify still expected github.com/smashingtags/... -> 'no matching signatures'. Update the --certificate-identity-regexp to imogenlabs. (The earlier v3 revert was a misdiagnosis; harmless.) NAMESPACE/publish path left unchanged.