### PR TITLE
HLCE-183: fix vitest e2e exclusion + drop deprecated tsconfig baseUrl

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { defineConfig } from "vite";
+import { defineConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
@@ -23,6 +23,10 @@ export default defineConfig({
         },
       },
     },
+  },
+  test: {
+    exclude: [...configDefaults.exclude, "tests/e2e/**"],
+    passWithNoTests: true,
   },
   server: {
     port: 8080,


### PR DESCRIPTION
Restores the test suite (vitest no longer runs Playwright e2e specs; passWithNoTests since there are no unit tests yet) and removes the deprecated baseUrl (unblocks the TS major in #226). Verified locally: build OK, vitest OK.