### PR TITLE
HLCE-184: manualChunks function form for Vite 8/rolldown (unblocks #227)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,9 +17,16 @@ export default defineConfig({
     sourcemap: false,
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ["react", "react-dom"],
-          icons: ["lucide-react"],
+        manualChunks(id) {
+          if (
+            id.includes("node_modules/react") ||
+            id.includes("node_modules/react-dom")
+          ) {
+            return "vendor";
+          }
+          if (id.includes("node_modules/lucide-react")) {
+            return "icons";
+          }
         },
       },
     },


### PR DESCRIPTION
Vite 8 (rolldown) requires manualChunks as a function. Backward-compatible with Vite 7. Verified locally: build OK on main's Vite 7.3.3, and OK with #227's Vite 8.0.16. Unblocks the dev-tools group #227.