### PR TITLE
HLCE-185: run security/compliance CI suite on self-hosted runners

### DIFF
--- a/.github/workflows/compliance-binder.yml
+++ b/.github/workflows/compliance-binder.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   collect:
     name: Collect compliance evidence
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dast-active.yml
+++ b/.github/workflows/dast-active.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   zap-active:
     name: ZAP Authenticated Active Scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/dast-baseline.yml
+++ b/.github/workflows/dast-baseline.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   zap-baseline:
     name: ZAP Passive Baseline
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/dast-trend.yml
+++ b/.github/workflows/dast-trend.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   trend:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/dependency-staleness.yml
+++ b/.github/workflows/dependency-staleness.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   staleness:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:

--- a/.github/workflows/deploy-drift.yml
+++ b/.github/workflows/deploy-drift.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:

--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   external-set:
     name: ATT&CK external (class A1)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,5 +1,6 @@
 name: OpenSSF Scorecard
 on:
+  workflow_dispatch:
   branch_protection_rule:
   schedule:
     - cron: '17 4 * * 1'
@@ -11,7 +12,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,6 @@
 name: Close inactive issues
 on:
+  workflow_dispatch:
   schedule:
     - cron: "30 1 * * *"
 
@@ -8,7 +9,7 @@ permissions:
 
 jobs:
   close-issues:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/whitelabel-audit.yml
+++ b/.github/workflows/whitelabel-audit.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   regenerate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     # Skip if the last commit was itself an audit regeneration,
     # so we don't loop forever.
     if: "!contains(github.event.head_commit.message, 'regenerate white-label audit')"


### PR DESCRIPTION
Moves all 11 cron security workflows to `[self-hosted, linux, x64]` so the suite keeps running without cloud minutes (deploy-drift alone was ~1,440 runs/mo). No cache usage = no self-hosted cache-hang. Added workflow_dispatch to scorecard + stale. Post-merge each workflow will be triggered and verified on a runner; any needing tooling not on the runners gets reverted to GitHub-hosted and called out.