### PR TITLE
HLCE-185: revert to GitHub-hosted (public repo = free minutes; self-hosted blocked for public)

### DIFF
--- a/.github/workflows/compliance-binder.yml
+++ b/.github/workflows/compliance-binder.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   collect:
     name: Collect compliance evidence
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dast-active.yml
+++ b/.github/workflows/dast-active.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   zap-active:
     name: ZAP Authenticated Active Scan
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/dast-baseline.yml
+++ b/.github/workflows/dast-baseline.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   zap-baseline:
     name: ZAP Passive Baseline
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/dast-trend.yml
+++ b/.github/workflows/dast-trend.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   trend:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/dependency-staleness.yml
+++ b/.github/workflows/dependency-staleness.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   staleness:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:

--- a/.github/workflows/deploy-drift.yml
+++ b/.github/workflows/deploy-drift.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:

--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   external-set:
     name: ATT&CK external (class A1)
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   close-issues:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/whitelabel-audit.yml
+++ b/.github/workflows/whitelabel-audit.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   regenerate:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     # Skip if the last commit was itself an audit regeneration,
     # so we don't loop forever.
     if: "!contains(github.event.head_commit.message, 'regenerate white-label audit')"


### PR DESCRIPTION
homelabarr-ce is public → free unlimited GitHub-hosted minutes, and public repos are blocked from the org self-hosted runners, so the migrated jobs queued forever. Reverting to ubuntu-latest so the suite runs free and green. Kept workflow_dispatch on scorecard/stale.