### PR TITLE
HLCE-186: fix backend crash loop (path-to-regexp override vs Express 5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9838,10 +9838,14 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
-    "path-to-regexp": "0.1.13",
+    "path-to-regexp": "^8.2.0",
     "qs": "6.14.2"
   }
 }


### PR DESCRIPTION
Backend crash-looped (166x) with `pathRegexp.match is not a function` — the `path-to-regexp: 0.1.13` override forced the Express-4 line onto Express 5's router. Changed override to `^8.2.0` (resolves 8.4.2: ReDoS-patched + Express-5 compatible). Verified locally the backend boots past route registration. Fixes 502 on ce-demo /api/*; defuses the prod time bomb.