### PR TITLE
HLCE-188: TruffleHog (CI) + Betterleaks (pre-commit) — drop license-blocked gitleaks-action

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -410,10 +410,15 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
           persist-credentials: false
-      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_VERSION: latest
+      - name: TruffleHog (verified secrets only)
+        # Replaces gitleaks-action, which now requires a paid license for org
+        # repos. TruffleHog scans full git history and --only-verified fails the
+        # job only on active/verified secrets. Local pre-commit (Betterleaks)
+        # handles the rule-based .gitleaks.toml checks before commit.
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/repo" \
+            ghcr.io/trufflesecurity/trufflehog:3.95.5 \
+            git file:///repo --only-verified --fail --no-update
 
   license-audit:
     name: License audit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# Pre-commit hooks for HomelabARR CE.
+#
+# Local secret-scanning gate: Betterleaks — the MIT-licensed, drop-in Gitleaks
+# successor by the original Gitleaks author. It reuses the existing .gitleaks.toml
+# rules and blocks secrets before they ever enter a commit. CI runs TruffleHog
+# (--only-verified) as the safety net that alerts on active/verified secrets;
+# see the secrets-scan job in .github/workflows/security-audit.yml.
+#
+# Setup:  pipx install pre-commit && pre-commit install
+# Manual: pre-commit run betterleaks --all-files
+repos:
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: v1.4.1
+    hooks:
+      - id: betterleaks


### PR DESCRIPTION
gitleaks-action now requires a paid org license (post-migration regression). Replaced the CI secrets-scan with TruffleHog 3.95.5 (--only-verified, full git history) and added a Betterleaks pre-commit hook (MIT, reuses .gitleaks.toml). Matches the agreed layered strategy: block locally, verify in CI.