### PR TITLE
HLCE-189: fix compose-security-validation install (mkdir -p ~/.local/bin)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -170,6 +170,7 @@ jobs:
             echo "Docker Compose not found, downloading..."
             # Download docker-compose binary
             COMPOSE_VERSION="2.36.2"
+            mkdir -p "$HOME/.local/bin"
             wget -q https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-x86_64 -O $HOME/.local/bin/docker-compose
             chmod +x $HOME/.local/bin/docker-compose
             export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
Install step wget'd docker-compose into ~/.local/bin without creating it; fails on ubuntu-24.04. Added mkdir -p, mirroring shell-security-analysis.