### PR TITLE
HLCE-189: fix compose validation step (filter + --no-interpolate) + tubesync volume

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -184,9 +184,20 @@ jobs:
       - name: Validate Docker Compose files
         run: |
           echo "Validating Docker Compose configurations..."
+          # Validate only real app compose templates: files with a top-level
+          # services: key, excluding GPU override fragments (.gpu/, merged into a
+          # base file at install time) and monitoring config/provisioning YAML
+          # (Prometheus/Loki/Grafana files that aren't compose projects).
+          # --no-interpolate: app-store templates use ${VARS} filled in at install
+          # time, so validate structure without resolving them (an unset image var
+          # would otherwise read as a blank image and fail validation).
           find apps -name "*.yml" -o -name "*.yaml" | while read -r compose_file; do
+            case "$compose_file" in
+              */.gpu/*|*/provisioning/*) continue ;;
+            esac
+            grep -qE "^services:" "$compose_file" || continue
             echo "Validating: $compose_file"
-            if ! docker-compose -f "$compose_file" config --quiet; then
+            if ! docker-compose -f "$compose_file" config --no-interpolate --quiet; then
               echo "::error::Docker Compose validation failed for $compose_file"
               exit 1
             else

--- a/apps/downloads/tubesync.yml
+++ b/apps/downloads/tubesync.yml
@@ -36,4 +36,3 @@ networks:
 volumes:
   unionfs:
     driver: local
-    driver_opts:


### PR DESCRIPTION
Validate step now targets only real app compose templates (top-level services:, excluding .gpu/ + provisioning/) and uses --no-interpolate so install-time ${VARS} don't read as blank images. Also fixes a real malformed template the job caught: tubesync.yml empty driver_opts. Verified locally: 117 templates validate, 0 failures.