### PR TITLE
ci: auto-build :dev on dev pushes (ce-dev auto-deploy)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
     tags: [ 'v*' ]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
ce-dev's :dev image only rebuilt on manual dispatch because the build workflow triggered on main only. Add dev to the push branches so dev merges auto-rebuild/redeploy ce-dev. :latest stays main-only.