### PR TITLE
HLCE-202: nodemailer 9 regression test + React 19 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # HomelabARR CE Changelog
 
+## [Unreleased]
+
+### ⬆️ Dependencies & Framework
+- **React 18 → 19**: upgraded `react`, `react-dom`, `@types/react`, `@types/react-dom` to 19.2.7 (matched majors). Resolves the recurring mismatched-major hazard where Dependabot tried to bump `react-dom` to 19 alone. ([#273](https://github.com/imogenlabs/homelabarr-ce/pull/273), HLCE-200)
+- **shadcn/ui modernization**: converted all 83 `React.forwardRef` wrappers across 16 `src/components/ui/*` components to React 19 ref-as-prop. No behavioral change. ([#273](https://github.com/imogenlabs/homelabarr-ce/pull/273), HLCE-201)
+- **lucide-react 0.344 → 1.21**: required for React 19 peer support (the old range hard-blocked installs). Brand icons were removed in lucide 1.x — swapped the `Github` icon on the login screen for `GitFork`. ([#276](https://github.com/imogenlabs/homelabarr-ce/pull/276)/[#277](https://github.com/imogenlabs/homelabarr-ce/pull/277), HLCE-202)
+- **radix-ui group**: all `@radix-ui/*` (direct + transitive) bumped to latest.
+- **Other deps**: `dockerode` 4 → 5, `better-sqlite3` 12.11.1, `nodemailer` 8 → 9, `@types/node` 26, dev-tools group. ([#276](https://github.com/imogenlabs/homelabarr-ce/pull/276)/[#277](https://github.com/imogenlabs/homelabarr-ce/pull/277), HLCE-202)
+
+### ✅ Tests
+- Added `server/email.test.js` (the repo's first unit test) covering the email transporter — stub fallback, real SMTP path, and an offline nodemailer 9 end-to-end send — to lock in the nodemailer 9 upgrade.
+
+---
+
 ## [v2.2.0] - April 14, 2026
 
 ### 🐛 Bug Fixes (Backported from Eight.ly fork)

--- a/server/email.test.js
+++ b/server/email.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import nodemailer from 'nodemailer';
+
+// Regression coverage for the nodemailer 9 upgrade (HLCE-202). server/email.js
+// builds its transporter at import time from env, so each case resets modules
+// and sets env before importing.
+describe('server/email transporter', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.SMTP_HOST;
+    delete process.env.SMTP_USER;
+    delete process.env.SMTP_PASS;
+  });
+
+  it('falls back to a stub transporter when SMTP_HOST is unset', async () => {
+    const { default: transporter } = await import('./email.js');
+    const info = await transporter.sendMail({ to: 'x@y.com', subject: 's', text: 'b' });
+    expect(info.messageId).toMatch(/^stub-/);
+  });
+
+  it('builds a real nodemailer Mail transport when SMTP_HOST is set', async () => {
+    process.env.SMTP_HOST = 'smtp.example.com';
+    process.env.SMTP_USER = 'u';
+    process.env.SMTP_PASS = 'p';
+    const { default: transporter } = await import('./email.js');
+    expect(typeof transporter.sendMail).toBe('function');
+    expect(transporter.constructor.name).toBe('Mail');
+  });
+
+  it('nodemailer 9 createTransport + sendMail works end-to-end (offline)', async () => {
+    const transporter = nodemailer.createTransport({ jsonTransport: true });
+    const info = await transporter.sendMail({
+      from: 'noreply@homelabarr.com',
+      to: 'user@example.com',
+      subject: 'smoke',
+      text: 'hi',
+    });
+    expect(info.messageId).toBeTruthy();
+    expect(info.envelope.to).toContain('user@example.com');
+  });
+});


### PR DESCRIPTION
Wrap-up for the React 19 campaign (Epic HLCE-199).

- **`server/email.test.js`** — repo's first unit test. Covers the email transporter stub fallback, the real SMTP path under nodemailer 9, and an offline nodemailer 9 end-to-end send. Resolves the one item that couldn't be runtime-verified during the dep rollup (server is plain JS). `vitest run`: 3 passed.
- **`CHANGELOG.md`** — `[Unreleased]` entry for the React 18→19 upgrade + forwardRef modernization + dependency rollup.

README/wiki already describe the stack version-accurately; historical security-audit docs left as point-in-time records.