### PR TITLE
HLCE-199: fix broken wiki links (strict mkdocs build passes)

### DIFF
--- a/wiki/docs/guides/contributing.md
+++ b/wiki/docs/guides/contributing.md
@@ -381,7 +381,7 @@ git rebase upstream/master
 - Share knowledge freely
 
 ### Code of Conduct
-We follow the [Contributor Covenant Code of Conduct](../CONTRIBUTING.md).
+We follow the [Contributor Covenant Code of Conduct](https://github.com/imogenlabs/homelabarr-ce/blob/main/.github/CODE_OF_CONDUCT.md).
 
 ### Getting Help
 - **Discord**: [HomelabARR Community](https://discord.gg/Pc7mXX786x)
@@ -420,8 +420,8 @@ Active contributors may be invited to join the maintainer team with:
 
 ### Documentation
 - [Architecture Overview](architecture.md)
-- [Deployment Guide](deployment-guide.md)
-- [Local Mode Guide](../install/local-mode.md)
+- [Quick Start](quick-start.md)
+- [Configuration](configuration.md)
 
 ### External Tools
 - [Docker Documentation](https://docs.docker.com/)

--- a/wiki/docs/guides/white-label.md
+++ b/wiki/docs/guides/white-label.md
@@ -80,7 +80,7 @@ find . -name "*.bak" -not -path "./node_modules/*" -delete
 - `.github/workflows/docker-build-push.yml` — env vars `FRONTEND_IMAGE_NAME` and `BACKEND_IMAGE_NAME`, OCI labels, Discord webhook
 - The historical narrative in `wiki/docs/guides/history.md` (leave this alone — see [Legal](#legal-what-you-must-keep) below)
 
-For the full file-by-file list with line numbers, see the [auto-generated audit](_white-label-audit.md). It's regenerated from the code on every push, so it never goes stale.
+For the full file-by-file list with line numbers, see the auto-generated audit at `docs/internal/_white-label-audit.md` in the repo. It's regenerated from the code on every push, so it never goes stale.
 
 ---
 
@@ -241,7 +241,7 @@ See [Contributing](contributing.md) for the usual pull request guide.
 
 ## The complete file audit
 
-The companion [auto-generated audit](_white-label-audit.md) lists every file and line number where a brand reference currently lives. It's regenerated automatically from the code on every push to `main`, so it's always current with what's actually in the repo — no stale documentation, no surprises.
+The companion auto-generated audit (`docs/internal/_white-label-audit.md` in the repo) lists every file and line number where a brand reference currently lives. It's regenerated automatically from the code on every push to `main`, so it's always current with what's actually in the repo — no stale documentation, no surprises.
 
 If your fork has diverged from upstream or you've added new files, run `bash scripts/generate-whitelabel-audit.sh` in your own repo to get a fresh audit.
 

--- a/wiki/mkdocs.yml
+++ b/wiki/mkdocs.yml
@@ -135,3 +135,4 @@ nav:
   - Project History: guides/history.md
   - White-Label & Forking: guides/white-label.md
   - FAQ & Troubleshooting: guides/faq.md
+  - Changelog: install/changelog.md


### PR DESCRIPTION
Fixes the pre-existing broken wiki links found during the docs sweep's strict-build check.

- **contributing.md** — Code of Conduct → real `.github/CODE_OF_CONDUCT.md`; Resources list `deployment-guide.md`/`local-mode.md` (neither exists) → real `quick-start.md` + `configuration.md`.
- **white-label.md** — `_white-label-audit.md` lives in `docs/internal/` (not on the wiki) → dropped dead links, kept prose pointing to the repo path.
- **mkdocs.yml** — added orphaned `install/changelog.md` to nav.

`mkdocs build --strict` now exits **0 with zero warnings** (was aborting on 5).