### PR TITLE
HLCE-195: build-push workflow manual-dispatch only (minutes out is permanent)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,9 +1,11 @@
 name: Build and Push Docker Images
 
 on:
-  push:
-    branches: [ main, dev ]
-    tags: [ 'v*' ]
+  # Manual-only. GitHub Actions minutes are exhausted and are NOT being restored,
+  # so an auto-trigger on push just fails at setup and spams red checks. Deploys
+  # are done by hand on ce-prod (see CLAUDE.md "Build & Deploy — MANUAL ONLY").
+  # Kept dispatchable for if/when a self-hosted runner exists.
+  # (Was: push to [main, dev] + v* tags.)
   workflow_dispatch:
     inputs:
       push_images:


### PR DESCRIPTION
Minutes are exhausted and **not being restored** (owner decision) — manual deploy on ce-prod is the model. So the auto-trigger on docker-build-push.yml only ever failed at setup and spammed red checks. Switched it to **workflow_dispatch-only** (kept runnable for a future self-hosted runner). Namespace was already fixed to imogenlabs in HLCE-194. No required status checks on main, so red CI never gated merges (verified).