### PR TITLE
HLCE-197: add CodeQL SAST workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+# Static analysis (SAST) for JS/TS. Clears OSSF Scorecard SAST alert (#85).
+# NOTE: GitHub Actions minutes are out and not being restored, so this will not
+# run on hosted runners today — it is correctly configured for when a runner
+# exists (HLCE-195/HLCE-197). Run manually via the "Run workflow" button if a
+# self-hosted runner is added.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 7 * * 1'  # weekly, Mondays 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
Adds the CodeQL SAST workflow OSSF Scorecard alert #85 is asking for: scans javascript-typescript on push-to-main + pull_request + weekly schedule (+ workflow_dispatch), uploads SARIF. SHA-pinned actions (checkout v6.0.3, codeql-action v4 — repo convention), least-privilege (`security-events: write`).

Minutes are out (permanent), so it can't run on hosted runners today — the file is the deliverable (AC1/AC2). AC3 (#85 auto-resolves) is gated on a runner; AC4 (#86 CI-Tests) is a dead-CI false-negative — dismissing those alerts is a security-settings action that's yours to make, not something I'll do unilaterally.