### PR TITLE
HLCE-199: pages.yml → ubuntu-latest (unblock wiki publish)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,9 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Wiki
-    runs-on: self-hosted
+    # Temporarily on hosted runners: the self-hosted gitrunners aren't picking up
+    # this repo's self-hosted jobs (under investigation). Hosted jobs are landing.
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Self-hosted gitrunners aren't picking up this repo's self-hosted jobs (pages.yml queues forever with idle matching runners; root cause TBD). Hosted runs work, so move the wiki deploy to ubuntu-latest to publish. Revert once the runner issue is fixed.