### PR TITLE
HLCE-203: revert pages.yml to self-hosted (gitrunners fixed)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,9 +19,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Wiki
-    # Temporarily on hosted runners: the self-hosted gitrunners aren't picking up
-    # this repo's self-hosted jobs (under investigation). Hosted jobs are landing.
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Runner-service restart cleared the wedged broker connection; all 4 gitrunners are Listening for Jobs again. Revert the ubuntu-latest wiki workaround back to self-hosted and confirm it deploys on a gitrunner.