### PR TITLE
HLCE-204: pages.yml on ubuntu-latest (public repo cannot use self-hosted runners)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,12 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Wiki
-    runs-on: self-hosted
+    # MUST be hosted: homelabarr-ce is a PUBLIC repo, and GitHub blocks public
+    # repos from the org's self-hosted runners (allows_public_repositories=false,
+    # a security default — fork PRs could compromise the host). So self-hosted
+    # jobs here queue forever regardless of runner capacity. Public repos get
+    # free unlimited hosted minutes, so ubuntu-latest is the correct home. See HLCE-204.
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Definitive fix: homelabarr-ce is a **public** repo, and GitHub blocks public repos from the org self-hosted runners (group `allows_public_repositories=false` — security default). So `runs-on: self-hosted` jobs here queue forever regardless of idle capacity. Public repos get free unlimited hosted minutes → `ubuntu-latest` is correct and works.