### PR TITLE
HLCE-214: Unit tests for MFA (TOTP + backup codes)

### DIFF
--- a/server/mfa.js
+++ b/server/mfa.js
@@ -7,8 +7,11 @@ import path from 'path';
 // Cost 12 in production; tests may lower it via BCRYPT_COST for speed.
 const BCRYPT_COST = Number(process.env.BCRYPT_COST) || 12;
 
-const MFA_FILE = path.join(process.cwd(), 'server', 'config', 'mfa.json');
-const PENDING_FILE = path.join(process.cwd(), 'server', 'config', 'mfa-pending.json');
+// Path seam: align with auth.js/stars.js (CONFIG_DIR) so tests redirect MFA
+// storage to a tmp dir instead of clobbering real server/config.
+const CONFIG_DIR = process.env.CONFIG_DIR || path.join(process.cwd(), 'server', 'config');
+const MFA_FILE = path.join(CONFIG_DIR, 'mfa.json');
+const PENDING_FILE = path.join(CONFIG_DIR, 'mfa-pending.json');
 
 function loadMfa() {
   try { return JSON.parse(fs.readFileSync(MFA_FILE, 'utf8')); } catch { return {}; }

--- a/server/mfa.test.js
+++ b/server/mfa.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// HLCE-214: MFA (TOTP window + backup codes + pending TTL).
+// mfa.js resolves CONFIG_DIR and BCRYPT_COST at import, so each test resets
+// modules and re-imports with env pointing at a throwaway tmp dir and a low
+// bcrypt cost. TOTP reads the wall clock, so the time-sensitive tests run under
+// vi fake timers.
+let tmp;
+
+async function loadMfa() {
+  vi.resetModules();
+  process.env.CONFIG_DIR = tmp;
+  process.env.BCRYPT_COST = '4';
+  return import('./mfa.js');
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hlce-mfa-'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  fs.rmSync(tmp, { recursive: true, force: true });
+  delete process.env.CONFIG_DIR;
+  delete process.env.BCRYPT_COST;
+});
+
+describe('newTotp', () => {
+  it('builds a 6-digit / 30s SHA1 TOTP with a base32 secret', async () => {
+    const mfa = await loadMfa();
+    const totp = mfa.newTotp('alice@homelabarr');
+    expect(totp.digits).toBe(6);
+    expect(totp.period).toBe(30);
+    expect(totp.secret.base32).toMatch(/^[A-Z2-7]+$/);
+  });
+});
+
+describe('verifyTotp (AC1, AC2)', () => {
+  const FIXED = new Date('2026-01-01T00:00:00Z').getTime();
+
+  it('verifies a freshly generated token under fixed fake time', async () => {
+    const mfa = await loadMfa();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED);
+    const totp = mfa.newTotp('alice');
+    const token = totp.generate();
+    expect(mfa.verifyTotp(totp.secret.base32, token)).toBe(true);
+  });
+
+  it('accepts a token one step earlier but rejects two steps earlier (window:1 boundary)', async () => {
+    const mfa = await loadMfa();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED);
+    const totp = mfa.newTotp('alice');
+    const secret = totp.secret.base32;
+    const prev1 = totp.generate({ timestamp: FIXED - 30_000 });
+    const prev2 = totp.generate({ timestamp: FIXED - 60_000 });
+    const next1 = totp.generate({ timestamp: FIXED + 30_000 });
+    expect(mfa.verifyTotp(secret, prev1)).toBe(true);
+    expect(mfa.verifyTotp(secret, next1)).toBe(true);
+    expect(mfa.verifyTotp(secret, prev2)).toBe(false);
+  });
+
+  it('rejects random, wrong-length, and non-numeric codes', async () => {
+    const mfa = await loadMfa();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED);
+    const totp = mfa.newTotp('alice');
+    const secret = totp.secret.base32;
+
+    // A 6-digit code that is none of the in-window valid tokens.
+    const valid = new Set([
+      totp.generate({ timestamp: FIXED - 30_000 }),
+      totp.generate({ timestamp: FIXED }),
+      totp.generate({ timestamp: FIXED + 30_000 }),
+    ]);
+    let wrong = '000000';
+    for (let i = 0; i < 1000; i++) {
+      const c = String(i).padStart(6, '0');
+      if (!valid.has(c)) { wrong = c; break; }
+    }
+
+    expect(mfa.verifyTotp(secret, wrong)).toBe(false);
+    expect(mfa.verifyTotp(secret, '12345')).toBe(false);
+    expect(mfa.verifyTotp(secret, '1234567')).toBe(false);
+    expect(mfa.verifyTotp(secret, 'abcdef')).toBe(false);
+    expect(mfa.verifyTotp(secret, '')).toBe(false);
+  });
+});
+
+describe('backup codes (AC3)', () => {
+  it('makeBackupCodes produces N unique 10-hex-char codes', async () => {
+    const mfa = await loadMfa();
+    const codes = mfa.makeBackupCodes(10);
+    expect(codes).toHaveLength(10);
+    for (const c of codes) expect(c).toMatch(/^[0-9a-f]{10}$/);
+    expect(new Set(codes).size).toBe(10);
+    // Respects a custom count.
+    expect(mfa.makeBackupCodes(3)).toHaveLength(3);
+  });
+
+  it('verifyBackupCode returns the matching index and -1 for a wrong code', async () => {
+    const mfa = await loadMfa();
+    const codes = mfa.makeBackupCodes(5);
+    const hashes = await mfa.hashBackupCodes(codes);
+    expect(await mfa.verifyBackupCode(codes[3], hashes)).toBe(3);
+    expect(await mfa.verifyBackupCode('not-a-real-code', hashes)).toBe(-1);
+  });
+
+  it('skips null slots (consumed codes) without matching them', async () => {
+    const mfa = await loadMfa();
+    const codes = mfa.makeBackupCodes(3);
+    const hashes = await mfa.hashBackupCodes(codes);
+    // Simulate code 0 already consumed (its hash nulled out).
+    hashes[0] = null;
+    // Code 1 still matches at its index; the nulled slot 0 is skipped.
+    expect(await mfa.verifyBackupCode(codes[1], hashes)).toBe(1);
+    // The consumed code no longer matches anything.
+    expect(await mfa.verifyBackupCode(codes[0], hashes)).toBe(-1);
+  });
+});
+
+describe('per-user MFA store', () => {
+  it('round-trips and disables MFA config for a user, persisting to CONFIG_DIR', async () => {
+    const mfa = await loadMfa();
+    expect(mfa.getMfaForUser('u1')).toBeNull();
+
+    mfa.saveMfaForUser('u1', { secret: 'BASE32SECRET', enabled: true });
+    expect(mfa.getMfaForUser('u1')).toEqual({ secret: 'BASE32SECRET', enabled: true });
+
+    // Stored on disk under the seam dir, and isolated per user.
+    expect(fs.existsSync(path.join(tmp, 'mfa.json'))).toBe(true);
+    expect(mfa.getMfaForUser('u2')).toBeNull();
+
+    mfa.disableMfaForUser('u1');
+    expect(mfa.getMfaForUser('u1')).toBeNull();
+  });
+});
+
+describe('pending MFA TTL (AC4)', () => {
+  it('returns a pending entry before expiry and null after', async () => {
+    const mfa = await loadMfa();
+    mfa.setPendingMfa('u1', { secret: 'S', codes: [], exp: Date.now() + 10_000 });
+    expect(mfa.getPendingMfa('u1')).toMatchObject({ secret: 'S' });
+
+    mfa.setPendingMfa('u2', { secret: 'S2', exp: Date.now() - 1 });
+    expect(mfa.getPendingMfa('u2')).toBeNull();
+  });
+
+  it('returns null for a user with no pending entry, and clearPendingMfa removes it', async () => {
+    const mfa = await loadMfa();
+    expect(mfa.getPendingMfa('ghost')).toBeNull();
+
+    mfa.setPendingMfa('u1', { secret: 'S', exp: Date.now() + 10_000 });
+    mfa.clearPendingMfa('u1');
+    expect(mfa.getPendingMfa('u1')).toBeNull();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,13 +49,14 @@ export default defineConfig({
       // only in the same PR that adds the tests backing the increase — never
       // lower them to make a red build pass. See HLCE-211.
       // 2026-06-20 HLCE-211 seed: lines 20 / statements 20 / functions 28 / branches 17.
-      // 2026-06-20 HLCE-212 (auth core tests): raised to just under the new
-      // baseline (lines 28.05 / statements 28.21 / functions 37.62 / branches 24.77).
+      // 2026-06-20 HLCE-212 (auth core tests): lines 27 / statements 27 / functions 35 / branches 23.
+      // 2026-06-20 HLCE-214 (MFA tests): raised to just under the new baseline
+      // (lines 28.95 / statements 29.32 / functions 40.54 / branches 25.34).
       thresholds: {
-        lines: 27,
-        statements: 27,
-        functions: 35,
-        branches: 23,
+        lines: 28,
+        statements: 28,
+        functions: 39,
+        branches: 24,
       },
     },
     // Two projects: backend (server/**) in node, frontend (src/**) in jsdom.


### PR DESCRIPTION
## What & why

Wave 2 of the test-coverage campaign (Epic [HLCE-209](https://mjashley.atlassian.net/browse/HLCE-209)). `server/mfa.js` (otpauth TOTP with a ±1-step window, bcrypt-hashed backup codes, pending-MFA TTL) had zero tests. TOTP depends on the wall clock, so the time-sensitive cases run under fake timers.

## Coverage (this PR)

`server/mfa.js`: **100% lines / 100% functions / 86.66% branches**. Overall repo ~28% → **~29%** lines; ratchet floor raised (lines 28 / statements 28 / functions 39 / branches 24).

## Acceptance criteria

- [x] AC1: under fixed fake time a fresh TOTP verifies; a token one step earlier passes and two steps earlier fails (window boundary).
- [x] AC2: random, wrong-length, and non-numeric codes fail.
- [x] AC3: `makeBackupCodes` makes N unique codes; `verifyBackupCode` returns the right index, `-1` on miss, and skips null (consumed) slots.
- [x] AC4: `setPendingMfa`/`getPendingMfa` honors TTL (expired → null); `clearPendingMfa` removes it.
- [x] AC5: `mfa.js` 100% line coverage (target 80%+).

## Notes

- Added a `CONFIG_DIR` path seam to `mfa.js` (mirrors `auth.js`/`stars.js`) so tests redirect storage to a tmp dir. No production behaviour change (same default).
- Window boundary uses `totp.generate({ timestamp })` to mint tokens at exact steps under `vi.setSystemTime`.

## Verification

```
npx vitest run server/mfa.test.js   # 10 pass, mfa.js 100% lines
npm run test:coverage               # full suite pass, raised thresholds met (exit 0)
npx eslint . && npx tsc --project tsconfig.app.json --noEmit   # clean
```

## Rollback

`git revert 37fcf4c` (single commit; tests + a path seam only).