### PR TITLE
HLCE-266: validation path check case-insensitive on field key

### DIFF
--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -59,10 +59,16 @@ describe('validateConfig — required fields', () => {
 });
 
 describe('validateConfig — path validation', () => {
-  // NOTE: validateConfig only runs path validation when the field NAME includes
-  // the lowercase substring "path" (validation.ts:21, case-sensitive), so the
-  // field name must contain lowercase "path".
+  // Path validation triggers when the field NAME contains "path" case-INsensitively
+  // (validation.ts uses key.toLowerCase().includes('path'), HLCE-266).
   const pathField = field({ name: 'configpath', label: 'Config Path', type: 'text' });
+
+  it('flags a camelCase path field (HLCE-266 — case-insensitive key match)', () => {
+    const camel = field({ name: 'dataPath', label: 'Data Path', type: 'text' });
+    const t = template([camel]);
+    const errors = validateConfig(t, { dataPath: 'relative/dir' }, false);
+    expect(errors).toContain('Data Path must be a valid absolute path');
+  });
 
   it('flags a path that does not start with /', () => {
     const t = template([pathField]);

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -17,8 +17,9 @@ export function validateConfig(
   // Validate paths
   Object.entries(config).forEach(([key, value]) => {
     const field = template.configFields?.find(f => f.name === key);
-    // Skip domain validation for path format
-    if (field?.type === 'text' && key.includes('path') && (value.includes('/path/to') || !value.startsWith('/'))) {
+    // Skip domain validation for path format. Case-insensitive on the key so
+    // camelCase fields (dataPath, configPath) aren't silently skipped (HLCE-266).
+    if (field?.type === 'text' && key.toLowerCase().includes('path') && (value.includes('/path/to') || !value.startsWith('/'))) {
       errors.push(`${field.label} must be a valid absolute path`);
     }
   });


### PR DESCRIPTION
`key.includes('path')` → `key.toLowerCase().includes('path')` so a camelCase field like `dataPath` no longer silently skips absolute-path validation. New camelCase test + corrected the stale comment. Found by the round-2 audit.

Bug: [HLCE-266](https://mjashley.atlassian.net/browse/HLCE-266)