### PR TITLE
HLCE-268: unify password minimum length to 12

### DIFF
--- a/server/routes/auth-admin.js
+++ b/server/routes/auth-admin.js
@@ -186,8 +186,8 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
       const { userId } = req.params;
       const { newPassword } = req.body;
 
-      if (!newPassword || newPassword.length < 6) {
-        return res.status(400).json({ error: 'Password must be at least 6 characters' });
+      if (!newPassword || newPassword.length < 12) {
+        return res.status(400).json({ error: 'Password must be at least 12 characters' });
       }
 
       const users = loadUsers();

--- a/server/routes/auth-admin.routes.test.js
+++ b/server/routes/auth-admin.routes.test.js
@@ -227,6 +227,8 @@ describe('admin user management & activity log (AC5)', () => {
 
     // Too-short password.
     expect((await mutate(boss, 'put', `/auth/users/${id}/password`).send({ newPassword: 'short' })).status).toBe(400);
+    // HLCE-268: 11 chars rejected — admin reset shares the 12-char minimum.
+    expect((await mutate(boss, 'put', `/auth/users/${id}/password`).send({ newPassword: 'elevenchars' })).status).toBe(400);
     // Missing user.
     expect((await mutate(boss, 'put', '/auth/users/nope/password').send({ newPassword: 'longenough12' })).status).toBe(404);
     // Success — the new password authenticates.

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -193,8 +193,8 @@ export default function authRoutes({ sendError, getRequestMeta, loginLimiter, lo
         return res.status(400).json({ error: 'Current and new password required' });
       }
 
-      if (newPassword.length < 6) {
-        return res.status(400).json({ error: 'New password must be at least 6 characters' });
+      if (newPassword.length < 12) {
+        return res.status(400).json({ error: 'New password must be at least 12 characters' });
       }
 
       const result = await changePassword(req.user.id, currentPassword, newPassword);

--- a/server/routes/auth.routes.test.js
+++ b/server/routes/auth.routes.test.js
@@ -288,13 +288,15 @@ describe('change-password (AC1-adjacent)', () => {
 
     expect((await hdrs(agent.post('/auth/change-password')).send({ currentPassword: 'changerpass' })).status).toBe(400);
     expect((await hdrs(agent.post('/auth/change-password')).send({ currentPassword: 'changerpass', newPassword: 'short' })).status).toBe(400);
-    expect((await hdrs(agent.post('/auth/change-password')).send({ currentPassword: 'wrong', newPassword: 'longenough1' })).status).toBe(400);
+    // HLCE-268: 11-char password rejected (min length is now 12, unified with reset).
+    expect((await hdrs(agent.post('/auth/change-password')).send({ currentPassword: 'changerpass', newPassword: 'elevenchars' })).status).toBe(400);
+    expect((await hdrs(agent.post('/auth/change-password')).send({ currentPassword: 'wrong', newPassword: 'twelvechars1' })).status).toBe(400);
 
-    const ok = await hdrs(agent.post('/auth/change-password')).send({ currentPassword: 'changerpass', newPassword: 'longenough1' });
+    const ok = await hdrs(agent.post('/auth/change-password')).send({ currentPassword: 'changerpass', newPassword: 'twelvechars1' });
     expect(ok.status).toBe(200);
 
     // The new password authenticates; the current session is kept alive.
-    expect((await request(app).post('/auth/login').send({ username: 'changer', password: 'longenough1' })).status).toBe(200);
+    expect((await request(app).post('/auth/login').send({ username: 'changer', password: 'twelvechars1' })).status).toBe(200);
     expect((await agent.get('/auth/me')).status).toBe(200);
   });
 });


### PR DESCRIPTION
change-password and admin password-reset enforced only 6 chars while forgot-password reset required 12. Unified all three to **12**. Tests updated (12-char happy paths + 11-char rejection on change-password and admin-reset). Found by the round-2 audit.

Bug: [HLCE-268](https://mjashley.atlassian.net/browse/HLCE-268)