### PR TITLE
HLCE-267: validate container web port in all enhanced-mount handlers

### DIFF
--- a/server/regression/enhanced-mount-port.regression.test.js
+++ b/server/regression/enhanced-mount-port.regression.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+
+// HLCE-267: every enhanced-mount handler must validate the container-reported
+// web port before fetching localhost — not just enable/disable. We mount the
+// factory with a dockerManager whose container reports a given HostPort and
+// assert: out-of-range → handled error + NO fetch; valid → fetch proxied.
+process.env.NODE_ENV = 'test';
+
+let request, express, enhancedMountRoutes;
+
+beforeAll(async () => {
+  request = (await import('supertest')).default;
+  express = (await import('express')).default;
+  enhancedMountRoutes = (await import('../routes/enhanced-mount.js')).default;
+});
+
+function buildApp(hostPort) {
+  const container = {
+    inspect: vi.fn().mockResolvedValue({
+      NetworkSettings: { Ports: { '8080/tcp': [{ HostPort: hostPort }] } },
+    }),
+  };
+  const deps = {
+    requireAuth: (req, _res, next) => { req.user = { id: 'u', role: 'admin' }; next(); },
+    sendError: (res, status, message) => res.status(status).json({ error: message }),
+    dockerManager: { getDocker: () => ({ getContainer: () => container }) },
+  };
+  const app = express();
+  app.use(express.json());
+  app.use('/enhanced-mount', enhancedMountRoutes(deps));
+  return app;
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) }));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe('HLCE-267 — enhanced-mount port guard on all handlers', () => {
+  it('GET /status rejects an out-of-range container port without fetching', async () => {
+    const res = await request(buildApp('999999')).get('/enhanced-mount/cid/status');
+    expect(res.status).toBe(500);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('POST /auth/start rejects a non-numeric container port without fetching', async () => {
+    const res = await request(buildApp('not-a-port')).post('/enhanced-mount/cid/auth/start').send({});
+    expect(res.status).toBe(500);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('GET /status proxies to the validated port when it is valid', async () => {
+    const res = await request(buildApp('18080')).get('/enhanced-mount/cid/status');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith('http://localhost:18080/api/v2/status');
+  });
+});

--- a/server/routes/enhanced-mount.js
+++ b/server/routes/enhanced-mount.js
@@ -5,6 +5,16 @@ const ALLOWED_PROVIDERS = ['local', 'google', 'dropbox', 'onedrive', 'sftp', 'we
 export default function enhancedMountRoutes({ sendError, dockerManager, requireAuth }) {
   const router = Router();
 
+  // Validate the container-reported web port before any localhost fetch. The
+  // enable/disable handlers already did this inline; the GET + auth handlers
+  // didn't, leaving an inconsistent localhost-fetch surface (HLCE-267). Throws
+  // (→ caught by each handler's try/catch → sendError) on a bad/out-of-range port.
+  const safeWebPort = (webPort) => {
+    const p = parseInt(webPort, 10);
+    if (isNaN(p) || p < 1 || p > 65535) throw new Error('Invalid container web port');
+    return p;
+  };
+
   router.get('/:containerId/status', requireAuth, async (req, res) => {
     try {
       const { containerId } = req.params;
@@ -23,7 +33,7 @@ export default function enhancedMountRoutes({ sendError, dockerManager, requireA
       }
 
       // Proxy request to container's API
-      const response = await fetch(`http://localhost:${webPort}/api/v2/status`);
+      const response = await fetch(`http://localhost:${safeWebPort(webPort)}/api/v2/status`);
       if (!response.ok) {
         throw new Error(`Container API returned ${response.status}`);
       }
@@ -56,7 +66,7 @@ export default function enhancedMountRoutes({ sendError, dockerManager, requireA
       }
 
       // Proxy request to container's API
-      const response = await fetch(`http://localhost:${webPort}/api/v2/providers`);
+      const response = await fetch(`http://localhost:${safeWebPort(webPort)}/api/v2/providers`);
       if (!response.ok) {
         throw new Error(`Container API returned ${response.status}`);
       }
@@ -89,7 +99,7 @@ export default function enhancedMountRoutes({ sendError, dockerManager, requireA
       }
 
       // Proxy request to container's API
-      const response = await fetch(`http://localhost:${webPort}/api/v2/costs`);
+      const response = await fetch(`http://localhost:${safeWebPort(webPort)}/api/v2/costs`);
       if (!response.ok) {
         throw new Error(`Container API returned ${response.status}`);
       }
@@ -122,7 +132,7 @@ export default function enhancedMountRoutes({ sendError, dockerManager, requireA
       }
 
       // Proxy request to container's API
-      const response = await fetch(`http://localhost:${webPort}/api/v2/performance`);
+      const response = await fetch(`http://localhost:${safeWebPort(webPort)}/api/v2/performance`);
       if (!response.ok) {
         throw new Error(`Container API returned ${response.status}`);
       }
@@ -250,7 +260,7 @@ export default function enhancedMountRoutes({ sendError, dockerManager, requireA
       }
 
       // Proxy request to container's auth API
-      const response = await fetch(`http://localhost:${webPort}/api/v2/auth/start`, {
+      const response = await fetch(`http://localhost:${safeWebPort(webPort)}/api/v2/auth/start`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -291,7 +301,7 @@ export default function enhancedMountRoutes({ sendError, dockerManager, requireA
       }
 
       // Proxy request to container's auth API
-      const response = await fetch(`http://localhost:${webPort}/api/v2/auth/complete`, {
+      const response = await fetch(`http://localhost:${safeWebPort(webPort)}/api/v2/auth/complete`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -332,7 +342,7 @@ export default function enhancedMountRoutes({ sendError, dockerManager, requireA
       }
 
       // Proxy request to container's auth API
-      const response = await fetch(`http://localhost:${webPort}/api/v2/auth/api-key`, {
+      const response = await fetch(`http://localhost:${safeWebPort(webPort)}/api/v2/auth/api-key`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -374,7 +384,7 @@ export default function enhancedMountRoutes({ sendError, dockerManager, requireA
       }
 
       // Proxy request to container's test API
-      const response = await fetch(`http://localhost:${webPort}/api/v2/auth/test`, {
+      const response = await fetch(`http://localhost:${safeWebPort(webPort)}/api/v2/auth/test`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
The GET handlers (status/providers/costs/performance) and POST auth/start,auth/complete fetched `http://localhost:${webPort}` with no validation — only enable/disable applied the range guard. Added a shared `safeWebPort()` and routed all 8 localhost fetches through it (invalid/out-of-range → handled error, no fetch). New regression test covers a GET + POST, valid + invalid port. Found by the round-2 audit.

Bug: [HLCE-267](https://mjashley.atlassian.net/browse/HLCE-267)