### PR TITLE
HLCE-280: frontend security fixes (rclone XSS, credential log, port validation)

### DIFF
--- a/src/components/EnhancedMountManager.tsx
+++ b/src/components/EnhancedMountManager.tsx
@@ -195,9 +195,11 @@ export const EnhancedMountManager: React.FC<Props> = ({ containerId, containerNa
     setAuthWizardOpen(true);
   };
 
-  const handleAuthComplete = (credentials: unknown) => {
-    console.log('Auth completed:', credentials);
-    // Refresh stats to show updated provider status
+  const handleAuthComplete = () => {
+    // Intentionally ignores the credentials arg — it carries freshly-minted
+    // rclone OAuth tokens / provider secrets; the previous `console.log` leaked
+    // them to the browser console (devtools history, screen-shares, extensions)
+    // (HLCE-280). Just refresh stats to show updated provider status.
     fetchEnhancedMountStats();
   };
 

--- a/src/components/RcloneAuthWizard.test.tsx
+++ b/src/components/RcloneAuthWizard.test.tsx
@@ -105,6 +105,32 @@ describe('RcloneAuthWizard', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  // HLCE-280 (XSS): a server-returned auth_url with a dangerous scheme must NOT
+  // become a live href. React doesn't sanitize javascript:/data: on an anchor,
+  // so safeExternalHref must strip it and the "open in new tab" link must not render.
+  it('does not render a javascript: auth_url as a clickable href', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      okJson({ success: true, data: { auth_url: 'javascript:alert(document.cookie)' } }),
+    );
+
+    renderWizard({ provider: 'gdrive' });
+    await user.click(screen.getByRole('button', { name: /generate auth url/i }));
+
+    // We're on the authorize step (the raw value shows in the readonly text input,
+    // which is harmless — it's text, not an executable sink).
+    await screen.findByDisplayValue('javascript:alert(document.cookie)');
+
+    // The "open in new tab" anchor (the XSS sink) must be absent / carry no
+    // javascript: href.
+    const link = screen.queryByRole('link', { name: /open in new tab/i });
+    expect(link).toBeNull();
+    for (const a of screen.queryAllByRole('link')) {
+      expect(a.getAttribute('href') ?? '').not.toMatch(/^javascript:/i);
+    }
+  });
+
   // AC4 (clipboard): copy the generated auth URL. Drive the copy click with
   // fireEvent rather than user-event — userEvent.setup() installs its own
   // navigator.clipboard stub, which would shadow the spy we asserted on.

--- a/src/components/RcloneAuthWizard.tsx
+++ b/src/components/RcloneAuthWizard.tsx
@@ -12,6 +12,7 @@ import {
   // Globe,
   // RefreshCw
 } from 'lucide-react';
+import { safeExternalHref } from '@/lib/safeUrl';
 
 // interface AuthStep {
 //   id: string;
@@ -329,15 +330,23 @@ const OAuthSetup: React.FC<{ provider: Provider; containerId: string; onComplete
               >
                 <Copy className="w-4 h-4" />
               </button>
-              <a
-                href={authUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="p-2 text-muted-foreground hover:text-foreground"
-                title="Open in new tab"
-              >
-                <ExternalLink className="w-4 h-4" />
-              </a>
+              {/* Guard the server-provided auth_url against javascript:/data:
+                  scheme injection (XSS) before using it as an href — same
+                  safeExternalHref guard DeployedAppCard uses (HLCE-280). */}
+              {(() => {
+                const safeAuthUrl = safeExternalHref(authUrl);
+                return safeAuthUrl ? (
+                  <a
+                    href={safeAuthUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-2 text-muted-foreground hover:text-foreground"
+                    title="Open in new tab"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                ) : null;
+              })()}
             </div>
           </div>
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -53,12 +53,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    // Track the cold-load retry timer + a cancelled flag so an unmount within
+    // the 1500ms window clears the pending timer and can't setState on an
+    // unmounted provider (HLCE-280).
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async session bootstrap: checkAuth sets user/loading on resolve, with a 1500ms cold-load retry. This is the documented "subscribe to an external system" effect shape; no cleaner idiom without a data-fetching library.
     checkAuth().then(ok => {
-      if (!ok) {
-        setTimeout(() => checkAuth(), 1500);
+      if (!ok && !cancelled) {
+        retryTimer = setTimeout(() => checkAuth(), 1500);
       }
     });
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+    };
   }, [checkAuth]);
 
   useEffect(() => {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -110,11 +110,31 @@ describe('validateConfig — port range validation', () => {
     expect(errors).not.toContain('Web Port must be a valid port number (1-65535)');
   });
 
-  it('warns (but does not invalidate) on a privileged port below 1024', () => {
+  it('does NOT block a privileged port below 1024 (HLCE-280: no warning pushed into errors[])', () => {
     const t = template([portField]);
     const errors = validateConfig(t, { webPort: '80' }, false);
-    expect(errors).toContain('Warning: Port 80 is a privileged port and may require elevated permissions');
-    expect(errors).not.toContain('Web Port must be a valid port number (1-65535)');
+    // Previously a "Warning: …privileged port" string was pushed into the
+    // blocking errors[] array, so DeployModal refused every deploy on 80/443.
+    expect(errors).toHaveLength(0);
+    expect(errors.some(e => /privileged/i.test(e))).toBe(false);
+  });
+
+  // HLCE-280 AC4: catalog apps render port fields as type 'text'; the range
+  // check must apply to them too (via isPortField), not only type 'number'.
+  it('range-validates a TEXT-typed port field (out-of-range rejected)', () => {
+    const textPort = field({ name: 'httpPort', label: 'HTTP Port', type: 'text' });
+    const t = template([textPort]);
+    expect(validateConfig(t, { httpPort: '99999' }, false))
+      .toContain('HTTP Port must be a valid port number (1-65535)');
+    expect(validateConfig(t, { httpPort: 'abc' }, false))
+      .toContain('HTTP Port must be a valid port number (1-65535)');
+  });
+
+  it('accepts a valid TEXT-typed port and does not block a privileged text port', () => {
+    const textPort = field({ name: 'httpPort', label: 'HTTP Port', type: 'text' });
+    const t = template([textPort]);
+    expect(validateConfig(t, { httpPort: '8080' }, false)).toHaveLength(0);
+    expect(validateConfig(t, { httpPort: '443' }, false)).toHaveLength(0);
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -24,19 +24,21 @@ export function validateConfig(
     }
   });
 
-  // Validate ports
+  // Validate ports — for number-typed fields AND text-typed catalog port fields
+  // (HLCE-276/280: catalog apps render ports as type 'text', so the old
+  // `type === 'number'` gate skipped their range validation entirely).
   Object.entries(config).forEach(([key, value]) => {
     const field = template.configFields?.find(f => f.name === key);
-    if (field?.type === 'number') {
+    if (isPortField(field, key)) {
       const port = parseInt(value, 10);
       if (isNaN(port) || port < 1 || port > 65535) {
-        errors.push(`${field.label} must be a valid port number (1-65535)`);
+        errors.push(`${field?.label ?? key} must be a valid port number (1-65535)`);
       }
-      
-      // Warn about privileged ports (below 1024) but don't block them
-      if (port < 1024 && port > 0) {
-        errors.push(`Warning: Port ${port} is a privileged port and may require elevated permissions`);
-      }
+      // NOTE: privileged ports (< 1024) are intentionally NOT flagged here.
+      // The previous "Warning: …privileged port" string was pushed into this
+      // blocking errors[] array, so DeployModal (which blocks on errors.length)
+      // silently refused every deploy on port 80/443/etc. (HLCE-280). Privileged
+      // ports are a legitimate operator choice; the backend governs the bind.
     }
   });
 


### PR DESCRIPTION
Remediation of the Opus 4.8 review frontend findings (epic HLCE-279). XSS guard on rclone auth_url (+test), removed credential console.log, privileged ports no longer blocked + text-port range validation (+tests), AuthContext retry-timer cleanup. tsc clean, lint 0 errors, 868 tests green. Rollback: git revert <merge>.