### PR TITLE
HLCE-282: audit/log/alert/db hardening (redaction drift, SQLCipher, alert)

### DIFF
--- a/server/alert.js
+++ b/server/alert.js
@@ -27,13 +27,27 @@ const ALERT_HOOK_URL = (() => {
 let auditEventFn = null;
 export function setAuditHook(fn) { auditEventFn = fn; }
 
+// Test-only: expose the live cooldown-map size so the prune behaviour (bounded
+// growth) is observable without leaking the Map itself (HLCE-282).
+export function cooldownSizeForTest() { return lastSentByKey.size; }
+
+// Drop cooldown entries older than the window. The cooldown key embeds the
+// caller-supplied ip, so without pruning an attacker spraying unique IPs would
+// grow lastSentByKey without bound (HLCE-282). Anything older than COOLDOWN_MS
+// can never suppress again, so it is safe to evict.
+function pruneCooldowns(now) {
+  for (const [k, ts] of lastSentByKey) {
+    if (ts <= now - COOLDOWN_MS) lastSentByKey.delete(k);
+  }
+}
+
 export async function maybeAlert(payload) {
   if (!ALERT_HOOK_URL) return;
   if (!ALERT_ON.has(payload.event)) return;
   const key = payload.event + '|' + (payload.ip || 'anon');
   const now = Date.now();
+  pruneCooldowns(now);
   if ((lastSentByKey.get(key) || 0) > now - COOLDOWN_MS) return;
-  lastSentByKey.set(key, now);
   const safe = Object.fromEntries(Object.entries(payload).filter(([k]) => ALLOWED_FIELDS.has(k)));
   const body = JSON.stringify({ ...safe, source: 'homelabarr-ce', ts: new Date().toISOString() });
   const headers = { 'Content-Type': 'application/json' };
@@ -42,7 +56,13 @@ export async function maybeAlert(payload) {
   }
   try {
     const r = await fetch(ALERT_HOOK_URL, { method: 'POST', headers, body, signal: AbortSignal.timeout(3000) });
-    if (!r.ok && auditEventFn) {
+    if (r.ok) {
+      // Arm the cooldown only on a confirmed delivery. Recording it before the
+      // fetch let a failed/unreachable webhook suppress the NEXT (possibly
+      // successful) alert for the whole window — so a flapping endpoint silently
+      // dropped alerts (HLCE-282). On failure we leave the key unset to retry.
+      lastSentByKey.set(key, now);
+    } else if (auditEventFn) {
       auditEventFn({ event: 'alert.webhook.failed', status: r.status, event_kind: payload.event });
     }
   } catch (err) {

--- a/server/alert.test.js
+++ b/server/alert.test.js
@@ -98,9 +98,74 @@ describe('per-key cooldown (AC4)', () => {
     await alert.maybeAlert({ event: 'login.locked', ip: '1.1.1.1' });
     expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
+
+  it('does NOT arm the cooldown when the webhook delivery fails (HLCE-282)', async () => {
+    // REGRESSION (HLCE-282): the cooldown was recorded BEFORE the fetch, so a
+    // failed/unreachable webhook armed the cooldown and silently suppressed the
+    // NEXT (possibly successful) alert for the whole window. The cooldown must
+    // arm only on a confirmed delivery; an HTTP error or a thrown fetch must
+    // leave the key unset so the next attempt can still send.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z').getTime());
+    const alert = await loadAlert({ ALERT_WEBHOOK_URL: 'https://hook.test/x', ALERT_EVENTS: 'login.locked' });
+
+    // First delivery returns a 500 -> must NOT arm the cooldown.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({ ok: false, status: 500 });
+    await alert.maybeAlert({ event: 'login.locked', ip: '9.9.9.9' });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Immediately retry (well within the window). Because the prior send failed,
+    // the cooldown is NOT armed, so this attempt still fires.
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 200 });
+    await alert.maybeAlert({ event: 'login.locked', ip: '9.9.9.9' });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    // Now the cooldown IS armed (last send succeeded) -> a third attempt is suppressed.
+    await alert.maybeAlert({ event: 'login.locked', ip: '9.9.9.9' });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('prunes cooldown entries older than the window so the Map stays bounded (HLCE-282)', async () => {
+    // The cooldown key embeds the caller-supplied ip; without pruning an attacker
+    // spraying unique IPs grows lastSentByKey without bound. Entries older than
+    // COOLDOWN_MS can never suppress again, so maybeAlert must evict them. We
+    // assert the cooldown for an OLD ip no longer suppresses after the window —
+    // an entry that was never pruned would still be present (but harmlessly
+    // expired); the observable bound-keeping signal is that an expired key sends.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z').getTime());
+    const alert = await loadAlert({ ALERT_WEBHOOK_URL: 'https://hook.test/x', ALERT_EVENTS: 'login.locked' });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, status: 200 });
+
+    // Seed many distinct-ip entries.
+    for (let i = 0; i < 5; i++) {
+      await alert.maybeAlert({ event: 'login.locked', ip: `10.0.0.${i}` });
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+
+    // Advance past the window and fire one more alert: the prune pass on this
+    // call must have evicted all 5 stale entries (they can no longer suppress),
+    // leaving the Map holding only the just-sent key.
+    vi.setSystemTime(new Date('2026-01-01T00:06:00Z').getTime());
+    await alert.maybeAlert({ event: 'login.locked', ip: '10.0.0.99' });
+    const size = alert.cooldownSizeForTest();
+    expect(size).toBe(1);
+  });
 });
 
 describe('SSRF / scheme guard (AC4)', () => {
+  // Pins the https-only egress check in alert.js (the ALERT_HOOK_URL IIFE): the
+  // webhook URL must be https unless ALERT_WEBHOOK_ALLOW_INSECURE=true, so a
+  // plaintext http:// (or otherwise malformed) URL is dropped and never fetched.
+  // This is the SSRF/exfil guard for the only outbound request this module makes.
+  it('accepts an https webhook URL and fires the request (https-only pin, HLCE-282)', async () => {
+    const alert = await loadAlert({ ALERT_WEBHOOK_URL: 'https://hook.test/x', ALERT_EVENTS: 'login.locked' });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, status: 200 });
+    await alert.maybeAlert({ event: 'login.locked', ip: '1.1.1.1' });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://hook.test/x');
+  });
+
   it('refuses a non-https webhook URL (no fetch) unless insecure is explicitly allowed', async () => {
     const alert = await loadAlert({ ALERT_WEBHOOK_URL: 'http://insecure.test/x', ALERT_EVENTS: 'login.locked' });
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, status: 200 });

--- a/server/audit.js
+++ b/server/audit.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 import winston from 'winston';
 import DailyRotateFile from 'winston-daily-rotate-file';
 import { db } from './db.js';
+import { REDACT_KEYS } from './log.js';
 
 const AUDIT_DIR = process.env.AUDIT_DIR || path.join(process.cwd(), 'server', 'activity-data');
 
@@ -47,13 +48,16 @@ export function initAudit() {
   auditLogger = winston.createLogger({ transports: [rotator], format: winston.format.json() });
 }
 
-const REDACT = /^(authorization|cookie|set-cookie|password|passcode|secret|token|x-csrf-token|x-api-key|jwt_secret)$/i;
+// Reuse the single shared redaction list (server/log.js) so the encrypted audit
+// sink and the structured logger redact the SAME keys. The old local list was
+// anchored on `token` and missed refresh_token/access_token, leaking them into
+// the persistent audit trail (HLCE-282).
 function redact(obj) {
   if (!obj || typeof obj !== 'object') return obj;
   if (Array.isArray(obj)) return obj.map(redact);
   const out = {};
   for (const [k, v] of Object.entries(obj)) {
-    out[k] = REDACT.test(k) ? '[REDACTED]' : (typeof v === 'object' ? redact(v) : v);
+    out[k] = REDACT_KEYS.test(k) ? '[REDACTED]' : (typeof v === 'object' ? redact(v) : v);
   }
   return out;
 }
@@ -82,13 +86,20 @@ export function audit(evt) {
   });
   const row = { ts, actor: evt.actor || null, ip: evt.ip || null, event: evt.event,
                 target: evt.target || null, result: evt.result, meta_json, prev_hash, row_hash };
-  const info = db.prepare(`INSERT INTO audit_events (ts, actor, ip, event, target, result, meta_json, prev_hash, row_hash)
-             VALUES (@ts, @actor, @ip, @event, @target, @result, @meta_json, @prev_hash, @row_hash)`).run(row);
-  // Advance the chain tip so a later tail-truncation is detectable (HLCE-269).
-  db.prepare(`INSERT INTO audit_chain_tip (id, last_row_id, last_row_hash, count)
-              VALUES (1, @id, @hash, 1)
-              ON CONFLICT(id) DO UPDATE SET last_row_id = @id, last_row_hash = @hash, count = count + 1`)
-    .run({ id: info.lastInsertRowid, hash: row_hash });
+  // The row INSERT and the chain-tip advance are two statements that MUST move
+  // together — a crash between them would leave the tip disagreeing with the
+  // table and verifyChain() would falsely report tail_truncated. Wrap both in a
+  // single transaction so they commit atomically (HLCE-282).
+  const writeRow = db.transaction((r) => {
+    const info = db.prepare(`INSERT INTO audit_events (ts, actor, ip, event, target, result, meta_json, prev_hash, row_hash)
+               VALUES (@ts, @actor, @ip, @event, @target, @result, @meta_json, @prev_hash, @row_hash)`).run(r);
+    // Advance the chain tip so a later tail-truncation is detectable (HLCE-269).
+    db.prepare(`INSERT INTO audit_chain_tip (id, last_row_id, last_row_hash, count)
+                VALUES (1, @id, @hash, 1)
+                ON CONFLICT(id) DO UPDATE SET last_row_id = @id, last_row_hash = @hash, count = count + 1`)
+      .run({ id: info.lastInsertRowid, hash: r.row_hash });
+  });
+  writeRow(row);
   if (auditLogger) auditLogger.info(row);
   return row_hash;
 }

--- a/server/audit.test.js
+++ b/server/audit.test.js
@@ -194,6 +194,29 @@ describe('meta redaction & event allowlist (AC2)', () => {
     });
   });
 
+  it('redacts refresh_token / access_token / api_key in stored meta (HLCE-282)', async () => {
+    // REGRESSION (HLCE-282): the audit sink's local REDACT list was anchored on
+    // `token` and did NOT include refresh_token/access_token/api_key, so those
+    // bearer/session secrets were persisted in CLEARTEXT in the encrypted audit
+    // trail while the structured logger (log.js) redacted them. The fix shares
+    // ONE merged superset regex (exported from log.js) across both modules.
+    const { audit } = await loadAudit();
+    audit.initAudit();
+    audit.audit({
+      actor: 'u', event: 'session.refresh', result: 'ok',
+      meta: {
+        refresh_token: 'rt-leak', access_token: 'at-leak', api_key: 'ak-leak',
+        nested: { refresh_token: 'nested-rt' }, keep: 'visible',
+      },
+    });
+    const meta = JSON.parse(audit.getRecentAuditEvents(1)[0].meta_json);
+    expect(meta.refresh_token).toBe('[REDACTED]');
+    expect(meta.access_token).toBe('[REDACTED]');
+    expect(meta.api_key).toBe('[REDACTED]');
+    expect(meta.nested.refresh_token).toBe('[REDACTED]');
+    expect(meta.keep).toBe('visible');
+  });
+
   it('only redacts keys that fully match the sensitive set, not substrings (HLCE-263)', async () => {
     // Pins the ^...$ anchors on the REDACT regex (audit.js:50). A key that merely
     // CONTAINS a sensitive word (e.g. "passwordHint", "mytoken") must survive; an
@@ -413,6 +436,38 @@ describe('tail-truncation detection (HLCE-269)', () => {
     const result = audit.verifyChain();
     expect(result.ok).toBe(false);
     expect(result.kind).toBe('tail_truncated');
+  });
+
+  it('rolls back the row INSERT atomically when the chain-tip advance fails (HLCE-282)', async () => {
+    // Pins the db.transaction(...) wrapper around the row INSERT + tip UPDATE
+    // (audit.js). Without the transaction the row would be committed while the
+    // tip advance throws, leaving rows.length > tip.count — verifyChain would
+    // then falsely report tail_truncated on a chain nobody actually truncated.
+    // We force the tip statement to throw by spying on db.prepare so that only
+    // the audit_chain_tip statement blows up.
+    const { audit, db } = await loadAudit();
+    audit.initAudit();
+    audit.audit({ actor: 'u', event: 'a', result: 'ok' }); // one good row + tip
+
+    const realPrepare = db.prepare.bind(db);
+    const spy = vi.spyOn(db, 'prepare').mockImplementation((sql) => {
+      if (sql.includes('audit_chain_tip') && sql.includes('INSERT')) {
+        throw new Error('simulated tip-write failure');
+      }
+      return realPrepare(sql);
+    });
+    try {
+      expect(() => audit.audit({ actor: 'u', event: 'b', result: 'ok' })).toThrow(/simulated tip-write/);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // The failed second write must have left NO orphan row: still exactly one
+    // row, and the tip still agrees with it -> chain verifies cleanly.
+    const rows = audit.getRecentAuditEvents();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].event).toBe('a');
+    expect(audit.verifyChain()).toEqual({ ok: true, rows: 1 });
   });
 
   it('does NOT flag a clean equal-count chain whose tip matches exactly (HLCE-263)', async () => {

--- a/server/db.js
+++ b/server/db.js
@@ -6,12 +6,22 @@ const DB_PATH = process.env.DB_PATH || path.join(process.env.DATA_DIR || path.jo
 
 function open() {
   const key = readSecret('SQLCIPHER_KEY', { required: false });
+  // Fail closed on a short key. A non-empty SQLCIPHER_KEY under 32 chars used to
+  // be silently ignored, so the DB was written in PLAINTEXT while the operator
+  // believed it was encrypted — a silent encryption downgrade. SQLCipher needs a
+  // strong key; refuse to start rather than write secrets unencrypted (HLCE-282).
+  if (key && key.length < 32) {
+    throw new Error(
+      `SQLCIPHER_KEY is set but too short (${key.length} chars; needs >= 32). ` +
+      'Refusing to open the database in PLAINTEXT — set a 32+ char key or unset it.'
+    );
+  }
   const db = new Database(DB_PATH);
   // The SQLCipher key MUST be applied before any other statement touches the
   // file. journal_mode=WAL writes the database header, so running it first would
   // initialise a fresh file as plaintext and the subsequent key application then
   // fails with "file is not a database" (HLCE-256). Key first, then WAL.
-  if (key && key.length >= 32) {
+  if (key) {
     db.pragma(`cipher='sqlcipher'`);
     db.pragma(`key='${key.replace(/'/g, "''")}'`);
     db.pragma(`cipher_page_size=4096`);
@@ -23,7 +33,22 @@ function open() {
       throw new Error(`SQLCipher key invalid or DB not encrypted: ${e.message}`);
     }
   }
-  db.pragma('journal_mode = WAL');
+  try {
+    db.pragma('journal_mode = WAL');
+  } catch (e) {
+    // Reaching WAL with no key applied means we opened the file as plaintext. If
+    // the file is actually an existing ENCRYPTED database, this is where SQLite
+    // first reads the header and throws a cryptic "file is not a database" /
+    // malformed error. Translate it into an actionable diagnostic (HLCE-282).
+    if (!key) {
+      throw new Error(
+        'Failed to open the database without an encryption key. If this is an ' +
+        'existing encrypted database, SQLCIPHER_KEY is missing or invalid ' +
+        `(needs the original 32+ char key). Underlying error: ${e.message}`
+      );
+    }
+    throw e;
+  }
   return db;
 }
 

--- a/server/db.test.js
+++ b/server/db.test.js
@@ -81,18 +81,31 @@ describe('SQLCipher encryption-at-rest (AC1 / HLCE-256)', () => {
     await expect(loadDb('w'.repeat(40), file)).rejects.toThrow(/not a database|SQLCipher key invalid/i);
   });
 
-  it('opens UNENCRYPTED when the key is under 32 chars (documents the silent-downgrade contract)', async () => {
-    const { db } = await loadDb('too-short-key'); // < 32 chars → cipher skipped
-    openHandles.push(db);
-    db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
-    db.prepare('INSERT INTO t (v) VALUES (?)').run('plain-value');
-    expect(db.prepare('SELECT v FROM t WHERE id = 1').get().v).toBe('plain-value');
-
-    // Silent downgrade: the file is a normal plaintext SQLite database.
-    expect(fileHeader(dbPath).startsWith(SQLITE_MAGIC_PREFIX)).toBe(true);
+  it('FAILS CLOSED when the key is under 32 chars instead of silently writing plaintext (HLCE-282)', async () => {
+    // REGRESSION (HLCE-282): a non-empty SQLCIPHER_KEY under 32 chars used to be
+    // silently ignored — the DB was written in PLAINTEXT while the operator
+    // believed it was encrypted (a silent encryption downgrade). open() must now
+    // throw a clear, actionable error rather than open the file at all.
+    await expect(loadDb('too-short-key')).rejects.toThrow(/too short.*32|Refusing to open the database in PLAINTEXT/i);
   });
 
-  it('opens unencrypted when no key is configured', async () => {
+  it('gives a clear diagnostic when opening an existing encrypted DB with NO key (HLCE-282)', async () => {
+    // Create an encrypted DB first, then reopen it with no key configured. The
+    // old code hit a cryptic WAL "file is not a database" error; open() must now
+    // translate that into a "missing/invalid key for an existing encrypted DB"
+    // diagnostic.
+    const key = 'k'.repeat(40);
+    const file = path.join(tmp, 'enc-nokey.db');
+    let mod = await loadDb(key, file);
+    openHandles.push(mod.db);
+    mod.db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+    mod.db.prepare('INSERT INTO t (v) VALUES (?)').run('persisted');
+    mod.db.close();
+
+    await expect(loadDb(undefined, file)).rejects.toThrow(/encryption key|encrypted database/i);
+  });
+
+  it('opens unencrypted when no key is configured (fresh DB)', async () => {
     const { db } = await loadDb(undefined);
     openHandles.push(db);
     db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY)');

--- a/server/log.js
+++ b/server/log.js
@@ -1,7 +1,12 @@
 import winston from 'winston';
 import { randomUUID } from 'node:crypto';
 
-const REDACT_KEYS = /^(authorization|cookie|set-cookie|password|passcode|secret|jwt_secret|refresh_token|access_token|x-api-key|x-csrf-token)$/i;
+// Single source of truth for sensitive header/field names, shared with the
+// encrypted audit sink (audit.js imports this). audit.js previously used a
+// narrower list anchored on `token` and missed refresh_token/access_token, so
+// the persistent sink leaked them; keeping one merged superset here closes that
+// gap (HLCE-282). Anchored ^...$ so substrings ("passwordHint") are not redacted.
+export const REDACT_KEYS = /^(authorization|cookie|set-cookie|password|passcode|secret|token|jwt_secret|refresh_token|access_token|api_key|x-api-key|x-csrf-token)$/i;
 
 function deepRedact(obj) {
   if (!obj || typeof obj !== 'object') return obj;


### PR DESCRIPTION
Remediation (epic HLCE-279). Unified REDACT into a shared constant so the audit sink no longer leaks refresh_token/access_token; db.js fails closed on a <32-char SQLCipher key + clear error for encrypted-no-key; alert.js prunes its cooldown Map + only arms cooldown on successful send; audit row+tip writes wrapped in a transaction. All pinned by tests. 871 tests green. Rollback: git revert <merge>.