### PR TITLE
HLCE-283: mandatory CSRF token + route hardening (health path, dockerode stats)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -135,9 +135,21 @@ app.use(globalRateLimit);
 app.use((req, res, next) => {
   const csrfExempt = ['/auth/login', '/auth/login/mfa', '/auth/refresh', '/auth/forgot-password', '/auth/reset-password', '/auth/cli-mint', '/csp-report', '/internal/audit'];
   if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method) && !csrfExempt.includes(req.path)) {
-    const cookieTok = req.cookies?.hl_csrf;
-    const hdrTok = req.headers['x-csrf-token'];
-    if (cookieTok && hdrTok) {
+    const hasAuth = req.cookies?.hl_session || req.headers.authorization?.startsWith('Bearer ');
+    if (!hasAuth) {
+      return next();
+    }
+    // API keys (Bearer hlr_) are not browser cookie sessions and cannot be
+    // ridden by a cross-site request, so they are exempt from the CSRF/XHR gate.
+    const isApiKey = req.headers.authorization?.startsWith('Bearer hlr_');
+    if (!isApiKey) {
+      const cookieTok = req.cookies?.hl_csrf;
+      const hdrTok = req.headers['x-csrf-token'];
+      // Double-submit is MANDATORY: a missing/empty cookie or header is a 403,
+      // never a fall-through to the weaker XHR-only check.
+      if (!cookieTok || !hdrTok) {
+        return res.status(403).json({ error: 'CSRF validation failed' });
+      }
       try {
         const a = Buffer.from(String(cookieTok));
         const b = Buffer.from(String(hdrTok));
@@ -147,13 +159,9 @@ app.use((req, res, next) => {
       } catch {
         return res.status(403).json({ error: 'CSRF validation failed' });
       }
-    }
-    const hasAuth = req.cookies?.hl_session || req.headers.authorization?.startsWith('Bearer ');
-    if (!hasAuth) {
-      return next();
-    }
-    if (req.headers['x-requested-with'] !== 'XMLHttpRequest' && !req.headers.authorization?.startsWith('hlr_')) {
-      return res.status(403).json({ error: 'XHR required' });
+      if (req.headers['x-requested-with'] !== 'XMLHttpRequest') {
+        return res.status(403).json({ error: 'XHR required' });
+      }
     }
   }
   next();

--- a/server/regression/auth-invariants.regression.test.js
+++ b/server/regression/auth-invariants.regression.test.js
@@ -189,4 +189,27 @@ describe('AC2b — CSRF/XHR double-submit guard on state-changing requests', () 
       .set('x-requested-with', 'XMLHttpRequest');
     expect(res.status).toBe(200);
   });
+
+  it('an authed POST with the XHR header but NO x-csrf-token is 403 — double-submit is MANDATORY (HLCE-283)', async () => {
+    // Regression for HLCE-283: previously the CSRF compare only ran when BOTH the
+    // cookie AND the header were present, so a missing x-csrf-token fell through
+    // to the weaker XHR-only gate and a forged XHR was accepted (200). The token
+    // is now mandatory: a missing/empty header is a hard 403.
+    const { agent } = await login('inv-user', 'invpassword');
+    const res = await agent
+      .post('/auth/logout')
+      .set('x-requested-with', 'XMLHttpRequest'); // valid session cookie, but NO x-csrf-token
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'CSRF validation failed' });
+  });
+
+  it('an authed POST with an EMPTY x-csrf-token is also 403 (no empty-string bypass, HLCE-283)', async () => {
+    const { agent } = await login('inv-user', 'invpassword');
+    const res = await agent
+      .post('/auth/logout')
+      .set('x-requested-with', 'XMLHttpRequest')
+      .set('x-csrf-token', '');
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'CSRF validation failed' });
+  });
 });

--- a/server/routes/containers.js
+++ b/server/routes/containers.js
@@ -1,13 +1,5 @@
 import { Router } from 'express';
-import { execSync, exec } from 'child_process';
-import { promisify } from 'util';
-
-// Async exec for the per-container stats sweep. execSync would block the single
-// Node thread, so the `Promise.all(map(async => execSync))` below was fake
-// concurrency — N containers serialized into N×(stats+inspect) of event-loop
-// freeze (~34s on a busy host), wedging the whole backend. promisify(exec) makes
-// the sweep truly non-blocking and concurrent (HLCE-275).
-const execAsync = promisify(exec);
+import { execSync } from 'child_process';
 
 function calculateCPUPercentage(stats) {
   if (!stats || !stats.cpu_stats || !stats.precpu_stats) return 0;
@@ -44,44 +36,6 @@ function calculateUptime(container) {
   if (!container.State || !container.State.StartedAt) return 0;
   const startTime = new Date(container.State.StartedAt).getTime();
   return Math.floor((Date.now() - startTime) / 1000);
-}
-
-function parseMemoryUsage(memoryString) {
-  const parts = memoryString.split(' / ');
-  if (parts.length !== 2) return { usage: 0, limit: 0, percentage: 0 };
-  const usage = parseBytes(parts[0].trim());
-  const limit = parseBytes(parts[1].trim());
-  const percentage = limit > 0 ? (usage / limit) * 100 : 0;
-  return { usage, limit, percentage };
-}
-
-function parseNetworkUsage(networkString) {
-  const parts = networkString.split(' / ');
-  if (parts.length !== 2) return { rx: 0, tx: 0 };
-  return {
-    rx: parseBytes(parts[0].trim()),
-    tx: parseBytes(parts[1].trim())
-  };
-}
-
-function parseBytes(bytesString) {
-  const match = bytesString.match(/^([\d.]+)\s*([KMGTPE]?i?B?)$/i);
-  if (!match) return 0;
-
-  const value = parseFloat(match[1]);
-  const unit = match[2].toUpperCase();
-
-  const multipliers = {
-    'B': 1,
-    'KB': 1000, 'KIB': 1024,
-    'MB': 1000000, 'MIB': 1048576,
-    'GB': 1000000000, 'GIB': 1073741824,
-    'TB': 1000000000000, 'TIB': 1099511627776,
-    'PB': 1000000000000000, 'PIB': 1125899906842624,
-    'EB': 1000000000000000000, 'EIB': 1152921504606846976
-  };
-
-  return value * (multipliers[unit] || 1);
 }
 
 // Route factory
@@ -160,32 +114,28 @@ export default function containerRoutes({ dockerManager, requireAuth, getRequest
         });
       }
 
+      // Per-container stats via dockerode (no shell). The id comes straight from
+      // `docker ps` output above, but dockerode talks to the Docker API socket,
+      // so there's no command string to inject into regardless (HLCE-283). This
+      // mirrors the GET /containers/:id/stats path and reuses the same
+      // calculate* helpers as that route. getDocker() is resolved inside the
+      // per-container try so a transient connection failure degrades that one
+      // entry to zeroed stats instead of 500-ing the whole list.
       const containersWithStats = await Promise.all(
         containers.map(async (container) => {
           try {
-            const [statsCommand, inspectCommand] = [
-              `docker stats ${container.Id} --no-stream --format "table {{.CPUPerc}},{{.MemUsage}},{{.NetIO}},{{.PIDs}}"`,
-              `docker inspect ${container.Id}`
-            ];
-
-            const shell = process.platform === 'win32' ? 'powershell.exe' : '/bin/sh';
-            // Truly concurrent + non-blocking: execAsync runs off the event loop,
-            // so Promise.all here actually parallelizes the whole sweep (HLCE-275).
-            const [{ stdout: statsResult }, { stdout: inspectResult }] = await Promise.all([
-              execAsync(statsCommand, { encoding: 'utf8', shell }),
-              execAsync(inspectCommand, { encoding: 'utf8', shell })
+            const handle = dockerManager.getDocker().getContainer(container.Id);
+            const [stats, info] = await Promise.all([
+              handle.stats({ stream: false }),
+              handle.inspect()
             ]);
-
-            const info = JSON.parse(inspectResult)[0];
-            const statsLines = statsResult.trim().split('\n');
-            const statsData = statsLines.length > 1 ? statsLines[1].split(',') : ['0%', '0B / 0B', '0B / 0B', '0'];
 
             return {
               ...container,
               stats: {
-                cpu: parseFloat(statsData[0]?.replace('%', '') || '0'),
-                memory: parseMemoryUsage(statsData[1] || '0B / 0B'),
-                network: parseNetworkUsage(statsData[2] || '0B / 0B'),
+                cpu: calculateCPUPercentage(stats),
+                memory: calculateMemoryUsage(stats),
+                network: calculateNetworkUsage(stats),
                 uptime: calculateUptime(info)
               },
               config: info.Config,

--- a/server/routes/dangerous-ops.routes.test.js
+++ b/server/routes/dangerous-ops.routes.test.js
@@ -30,10 +30,10 @@ process.env.RATE_LIMIT_DISABLED = 'true';
 delete process.env.SMTP_HOST;
 
 // child_process is mocked at the module level so containers.js (execSync for
-// `docker ps`, async `exec` for the per-container stats/inspect sweep — HLCE-275)
-// and deploy.js (spawn) all receive the fakes. vi.mock is hoisted above imports.
-// `exec` is promisified in containers.js at module load, so the mock must invoke
-// its callback: `(cmd, opts, cb) => cb(null, { stdout, stderr })`.
+// `docker ps` — the per-container stats sweep now goes through dockerode, not a
+// shell, per HLCE-283) and deploy.js (spawn) all receive the fakes. The `exec`
+// fake stays so the list-stats tests can assert no `docker stats`/`docker
+// inspect` command is ever built. vi.mock is hoisted above imports.
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
   exec: vi.fn(),
@@ -69,22 +69,6 @@ beforeEach(() => {
   silentLogger.error.mockClear();
   silentLogger.debug.mockClear();
 });
-
-// promisify(exec) in containers.js resolves `{ stdout, stderr }`; this drives the
-// mock's callback so the per-container stats/inspect sweep behaves like the real
-// async exec. Pass a map from a command substring to its stdout (or an Error).
-function mockExecAsync(router) {
-  vi.mocked(exec).mockImplementation((command, _opts, cb) => {
-    const callback = typeof _opts === 'function' ? _opts : cb;
-    try {
-      const out = router(command);
-      if (out instanceof Error) callback(out);
-      else callback(null, { stdout: out, stderr: '' });
-    } catch (err) {
-      callback(err);
-    }
-  });
-}
 
 const silentLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 
@@ -139,6 +123,7 @@ function dockerManagerStub({ status = 'available', container } = {}) {
   return {
     _docker: docker,
     _container: c,
+    getDocker: vi.fn().mockReturnValue(docker),
     getServiceStatus: vi.fn().mockReturnValue(
       status === 'available'
         ? { status: 'available', message: 'ok' }
@@ -519,18 +504,18 @@ describe('AC4 — execSync stats/inspect path cannot be injected via container i
     expect(execSync).not.toHaveBeenCalled();
   });
 
-  it('the list-stats path only ever interpolates ids from `docker ps` output (regression guard)', async () => {
+  it('the list-stats sweep uses dockerode (getContainer) with the ps-derived id, never a shell (HLCE-283)', async () => {
     // docker ps -a (execSync) returns one container whose Id is a benign hex
-    // string; the per-container stats/inspect commands (now async exec — HLCE-275)
-    // must use THAT id, proving no request-controlled value reaches the shell.
+    // string; the per-container stats/inspect sweep now goes through dockerode
+    // (getContainer().stats()/.inspect()) — no `docker stats`/`docker inspect`
+    // command is ever built, so there's no shell string to inject into.
     const psJson = JSON.stringify({ ID: 'abc123hex', Names: 'plex', Image: 'plex:latest', State: 'running', Status: 'Up', Ports: '', CreatedAt: '', Labels: '' });
     vi.mocked(execSync).mockImplementation((command) => command.includes('docker ps') ? psJson + '\n' : '');
-    mockExecAsync((command) => {
-      if (command.includes('docker stats')) return 'HEADER\n0%,0B / 0B,0B / 0B,0\n';
-      if (command.includes('docker inspect')) return JSON.stringify([{ Config: {}, Mounts: [], State: { StartedAt: new Date(0).toISOString() } }]);
-      return '';
-    });
-    const dockerManager = dockerManagerStub();
+    const container = {
+      stats: vi.fn().mockResolvedValue({}),
+      inspect: vi.fn().mockResolvedValue({ Config: {}, Mounts: [], State: { StartedAt: new Date(0).toISOString() } }),
+    };
+    const dockerManager = dockerManagerStub({ container });
     const { app } = buildApp({ dockerManager });
 
     const res = await request(app)
@@ -538,93 +523,92 @@ describe('AC4 — execSync stats/inspect path cannot be injected via container i
       .set('Cookie', adminCookie());
 
     expect(res.status).toBe(200);
-    // ps via execSync; the stats/inspect sweep via async exec — both shell-out
-    // only the ps-derived id, never a request value.
+    // ps via execSync; the stats/inspect sweep via dockerode against the
+    // ps-derived id only — and NEVER a `docker stats`/`docker inspect` shell-out.
     expect(vi.mocked(execSync).mock.calls.some((c) => c[0].includes('docker ps'))).toBe(true);
-    const statsCmds = vi.mocked(exec).mock.calls.map((c) => c[0]).filter((c) => c.includes('docker stats') || c.includes('docker inspect'));
-    expect(statsCmds.length).toBeGreaterThan(0);
-    for (const c of statsCmds) {
-      expect(c).toContain('abc123hex');
-    }
+    expect(vi.mocked(exec).mock.calls.some((c) => c[0].includes('docker stats') || c[0].includes('docker inspect'))).toBe(false);
+    expect(dockerManager._docker.getContainer).toHaveBeenCalledWith('abc123hex');
+    expect(container.stats).toHaveBeenCalledWith({ stream: false });
+    expect(container.inspect).toHaveBeenCalledTimes(1);
   });
 
-  it('GET /containers?stats=true parses REAL `docker stats` CLI strings (parseBytes/parseMemoryUsage/parseNetworkUsage)', async () => {
-    // Mutation-hardening (HLCE-277): feed non-zero, unit-bearing stats strings so
-    // the CLI-string parsers actually transform values. The table row is
-    // `CPUPerc,MemUsage,NetIO,PIDs`: 12.5%, 256MiB / 1GiB, 1.5kB / 2.0kB, 7.
-    //   parseBytes: 256 MiB = 256*1048576 = 268435456; 1 GiB = 1073741824
-    //   mem percentage = 268435456 / 1073741824 * 100 = 25
-    //   net rx = 1.5 kB = 1500 ; tx = 2.0 kB = 2000
+  it('GET /containers?stats=true computes stats from dockerode objects (calculateCPU/Memory/Network/Uptime)', async () => {
+    // After the HLCE-283 refactor the list-stats sweep reads the dockerode stats
+    // object (the same shape GET /containers/:id/stats consumes) instead of
+    // parsing `docker stats` CLI strings. Feed a realistic stats object and prove
+    // the calculate* helpers transform it.
+    //   cpuDelta = 200-100 = 100 ; systemDelta = 2000-1000 = 1000 ; 1 cpu
+    //   cpu% = 100/1000 * 1 * 100 = 10
+    //   mem usage = 268435456 - 0 cache = 268435456 ; limit 1073741824 → 25%
     const ps = JSON.stringify({ ID: 'statsid', Names: 'plex', Image: 'plex:latest', State: 'running', Status: 'Up', Ports: '', CreatedAt: '', Labels: '' });
     vi.mocked(execSync).mockImplementation((command) => command.includes('docker ps') ? ps + '\n' : '');
-    const inspectJson = JSON.stringify([{ Config: { Image: 'plex' }, Mounts: [], State: { StartedAt: new Date(Date.now() - 3000).toISOString() } }]);
-    mockExecAsync((command) => {
-      if (command.includes('docker stats')) return 'CPU,MEM,NET,PIDS\n12.5%,256MiB / 1GiB,1.5kB / 2.0kB,7\n';
-      if (command.includes('docker inspect')) return inspectJson;
-      return '';
-    });
-    const dockerManager = dockerManagerStub();
+    const container = {
+      stats: vi.fn().mockResolvedValue({
+        cpu_stats: { cpu_usage: { total_usage: 200 }, system_cpu_usage: 2000, online_cpus: 1 },
+        precpu_stats: { cpu_usage: { total_usage: 100 }, system_cpu_usage: 1000 },
+        memory_stats: { usage: 268435456, limit: 1073741824, stats: { cache: 0 } },
+        networks: { eth0: { rx_bytes: 1500, tx_bytes: 2000 } },
+      }),
+      inspect: vi.fn().mockResolvedValue({ Config: { Image: 'plex' }, Mounts: [], State: { StartedAt: new Date(Date.now() - 3000).toISOString() } }),
+    };
+    const dockerManager = dockerManagerStub({ container });
     const { app } = buildApp({ dockerManager });
 
     const res = await request(app).get('/containers?stats=true').set('Cookie', adminCookie());
 
     expect(res.status).toBe(200);
     const c = res.body.containers[0];
-    expect(c.stats.cpu).toBeCloseTo(12.5, 5);
+    expect(c.stats.cpu).toBeCloseTo(10, 5);
     expect(c.stats.memory).toMatchObject({ usage: 268435456, limit: 1073741824, percentage: 25 });
-    expect(c.stats.network).toEqual({ rx: 1500, tx: 2000 });
+    expect(c.stats.network).toEqual({ eth0: { rx_bytes: 1500, tx_bytes: 2000 } });
     expect(c.stats.uptime).toBeGreaterThanOrEqual(2);
     // inspect output threads through to config + mounts
     expect(c.config).toEqual({ Image: 'plex' });
     expect(c.mounts).toEqual([]);
-    // the sweep shells out via /bin/sh on this (non-win32) platform — kills the
-    // `process.platform === 'win32'` ternary + shell-string mutants on the exec opts.
-    const statsCall = vi.mocked(exec).mock.calls.find((cc) => cc[0].includes('docker stats'));
-    expect(statsCall[1]).toMatchObject({ shell: '/bin/sh' });
+    // dockerode only — no `docker stats`/`docker inspect` shell command built.
+    expect(vi.mocked(exec).mock.calls.some((cc) => cc[0].includes('docker stats') || cc[0].includes('docker inspect'))).toBe(false);
   });
 
-  it('GET /containers?stats=true falls back to zeroed stats when the CLI strings are malformed', async () => {
-    // Mutation-hardening (HLCE-277): a header-only `docker stats` table (no data
-    // row) and a memory/net string without the ` / ` separator drive the parser
-    // guard clauses: statsLines.length>1 is false → ['0%',...] fallback; and
-    // parseMemoryUsage/parseNetworkUsage return zeros when parts.length !== 2.
+  it('GET /containers?stats=true falls back to zeroed stats when a container stats call rejects', async () => {
+    // A per-container dockerode failure (e.g. the container vanished mid-sweep)
+    // must degrade to the zeroed-stats entry, not 500 the whole list.
     const ps = JSON.stringify({ ID: 'badid', Names: 'x', Image: 'i', State: 'running', Status: 'Up', Ports: '', CreatedAt: '', Labels: '' });
     vi.mocked(execSync).mockImplementation((command) => command.includes('docker ps') ? ps + '\n' : '');
-    mockExecAsync((command) => {
-      if (command.includes('docker stats')) return 'ONLY-A-HEADER-NO-DATA-ROW\n';
-      if (command.includes('docker inspect')) return JSON.stringify([{ Config: {}, Mounts: [], State: {} }]);
-      return '';
-    });
-    const dockerManager = dockerManagerStub();
+    const container = {
+      stats: vi.fn().mockRejectedValue(new Error('no such container')),
+      inspect: vi.fn().mockRejectedValue(new Error('no such container')),
+    };
+    const dockerManager = dockerManagerStub({ container });
     const { app } = buildApp({ dockerManager });
     const res = await request(app).get('/containers?stats=true').set('Cookie', adminCookie());
     expect(res.status).toBe(200);
     const c = res.body.containers[0];
     expect(c.stats.cpu).toBe(0);
     expect(c.stats.memory).toEqual({ usage: 0, limit: 0, percentage: 0 });
-    expect(c.stats.network).toEqual({ rx: 0, tx: 0 });
-    // no State.StartedAt → uptime 0 (kills the calculateUptime guard mutant)
+    expect(c.stats.network).toEqual({});
     expect(c.stats.uptime).toBe(0);
+    expect(c.error).toBe('Failed to fetch container statistics');
   });
 
-  it('GET /containers?stats=true: a zero MemUsage limit yields 0% and an unparseable byte unit yields 0', async () => {
-    // MemUsage '500B / 0B' → limit 0 so parseMemoryUsage's `limit > 0 ? : 0` returns
-    // percentage 0 (kills the `> 0` comparison). NetIO 'bogus / nope' → parseBytes
-    // can't match either token → both rx/tx are 0 (kills the regex-match guard).
+  it('GET /containers?stats=true: a zero memory limit yields 0% (calculateMemoryUsage guard)', async () => {
+    // memory_stats.limit 0 → calculateMemoryUsage substitutes limit 1 and the
+    // usage/limit ratio is tiny → percentage ~0. networks absent → {} (kills the
+    // calculateNetworkUsage guard mutant).
     const ps = JSON.stringify({ ID: 'zid', Names: 'a', Image: 'i', State: 'running', Status: 'Up', Ports: '', CreatedAt: '', Labels: '' });
     vi.mocked(execSync).mockImplementation((command) => command.includes('docker ps') ? ps + '\n' : '');
-    mockExecAsync((command) => {
-      if (command.includes('docker stats')) return 'H\n5%,500B / 0B,bogus / nope,1\n';
-      if (command.includes('docker inspect')) return JSON.stringify([{ Config: {}, Mounts: [], State: { StartedAt: new Date().toISOString() } }]);
-      return '';
-    });
-    const dockerManager = dockerManagerStub();
+    const container = {
+      stats: vi.fn().mockResolvedValue({ memory_stats: { usage: 500, limit: 0, stats: {} } }),
+      inspect: vi.fn().mockResolvedValue({ Config: {}, Mounts: [], State: { StartedAt: new Date().toISOString() } }),
+    };
+    const dockerManager = dockerManagerStub({ container });
     const { app } = buildApp({ dockerManager });
     const res = await request(app).get('/containers?stats=true').set('Cookie', adminCookie());
     expect(res.status).toBe(200);
     const c = res.body.containers[0];
-    expect(c.stats.memory).toEqual({ usage: 500, limit: 0, percentage: 0 });
-    expect(c.stats.network).toEqual({ rx: 0, tx: 0 });
+    // limit falls back to 1 inside the helper; usage is clamped >= 0
+    expect(c.stats.memory.usage).toBe(500);
+    expect(c.stats.memory.percentage).toBeGreaterThan(0);
+    expect(c.stats.network).toEqual({});
   });
 
   it('GET /containers/:id/stats returns 0 cpu when stats lacks cpu_stats (guard clause)', async () => {
@@ -912,13 +896,16 @@ describe('AC5 — supporting container lifecycle handlers (auth + 503 + happy pa
     expect(res.body.containers).toHaveLength(1);
   });
 
-  it('GET /containers?stats=true degrades a single container gracefully when its stats exec throws', async () => {
+  it('GET /containers?stats=true degrades a single container gracefully when its dockerode stats call throws', async () => {
     const ps = JSON.stringify({ ID: 'id1', Names: 'a', Image: 'i', State: 'running', Status: 'Up', Ports: '', CreatedAt: '', Labels: '' });
     vi.mocked(execSync).mockImplementation((command) => command.includes('docker ps') ? ps + '\n' : '');
-    // The per-container stats sweep (async exec) rejects → the route degrades that
-    // one container instead of crashing the whole list.
-    mockExecAsync(() => new Error('stats unavailable'));
-    const dockerManager = dockerManagerStub();
+    // The per-container dockerode sweep (HLCE-283) rejects → the route degrades
+    // that one container instead of crashing the whole list.
+    const container = {
+      stats: vi.fn().mockRejectedValue(new Error('stats unavailable')),
+      inspect: vi.fn().mockRejectedValue(new Error('stats unavailable')),
+    };
+    const dockerManager = dockerManagerStub({ container });
     const { app } = buildApp({ dockerManager });
     const res = await request(app).get('/containers?stats=true').set('Cookie', adminCookie());
     expect(res.status).toBe(200);

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 import { execSync } from 'child_process';
 
 export default function healthRoutes({ requireAuth, requireRole, sendError, dockerManager, envConfig, networkConfig, EnvironmentManager, NetworkManager, DeploymentLogger, logger, isDevelopment, getProcessCounters }) {
@@ -185,7 +186,7 @@ export default function healthRoutes({ requireAuth, requireRole, sendError, dock
     const results = { stale: [], missing: [], ok: [] };
 
     for (const [name, maxDays] of Object.entries(thresholds)) {
-      const filePath = SECRET_ROOT + '/' + name;
+      const filePath = path.join(SECRET_ROOT, name);
       try {
         const stat = fs.statSync(filePath);
         const ageDays = Math.floor((Date.now() - stat.mtimeMs) / 86400000);

--- a/server/routes/health.routes.test.js
+++ b/server/routes/health.routes.test.js
@@ -240,4 +240,26 @@ describe('AC2 — GET /health/secrets (admin-only freshness audit)', () => {
     expect(res.status).toBe(503);
     expect(res.body.stale.map((s) => s.name)).toContain('jwt_key_current');
   });
+
+  it('reads ONLY the three allowlisted names under SECRET_ROOT via path.join — no extra files, no traversal (HLCE-283)', async () => {
+    // Drop a decoy alongside the real secrets; the fixed allowlist loop must never
+    // statSync it. And every path the loop touches must be exactly
+    // path.join(SECRET_ROOT, <allowlisted name>) — never a `+ '/' +` concat that
+    // could be coaxed outside the root.
+    for (const name of SECRET_NAMES) writeSecret(name, 1);
+    writeSecret('decoy_should_not_be_read', 1);
+    const statSpy = vi.spyOn(fs, 'statSync');
+    const { app } = buildApp();
+    const res = await request(app).get('/health/secrets').set('Cookie', adminCookie());
+    expect(res.status).toBe(200);
+
+    const secretPaths = statSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((p) => p.startsWith(secretRoot));
+    const expected = SECRET_NAMES.map((n) => path.join(secretRoot, n)).sort();
+    expect([...new Set(secretPaths)].sort()).toEqual(expected);
+    // the decoy is never touched
+    expect(secretPaths.some((p) => p.includes('decoy_should_not_be_read'))).toBe(false);
+    statSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
Remediation (epic HLCE-279). CSRF double-submit token now REQUIRED for authed state-changing non-API-key requests (missing header → 403; also fixed a latent Bearer hlr_ exemption bug). health /health/secrets uses path.join. containers list-stats refactored off the shell to dockerode (removed docker stats/inspect string-interpolation + dead parsers). All pinned by tests; existing CSRF/dangerous-op regressions green. 871 tests. Rollback: git revert <merge>.