### PR TITLE
HLCE-285: harden auth routes — cli-mint jti-less+ttl, constant-time validatePassword, MFA invariant pins

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -133,12 +133,22 @@ export async function createUser(userData) {
   return userWithoutPassword;
 }
 
+// A fixed, valid bcrypt hash used only to equalize timing when the requested
+// user does not exist. Without this, the absent-user path skips bcrypt entirely
+// and returns much faster than the present-user path, giving an attacker a
+// timing oracle to enumerate valid usernames. Comparing against this dummy makes
+// both paths pay roughly the same bcrypt cost before returning null.
+const DUMMY_PASSWORD_HASH = bcrypt.hashSync('homelabarr-timing-equalizer', BCRYPT_COST);
+
 export async function validatePassword(username, password) {
   const user = findUserByUsername(username);
   if (!user) {
+    // Run a throwaway compare so timing matches the known-user path (constant
+    // against username enumeration), then fail closed.
+    await bcrypt.compare(password, DUMMY_PASSWORD_HASH);
     return null;
   }
-  
+
   const isValid = await bcrypt.compare(password, user.password);
   if (!isValid) {
     return null;
@@ -165,12 +175,12 @@ export async function validatePassword(username, password) {
   return userWithoutPassword;
 }
 
-export function generateToken(user, jti) {
+export function generateToken(user, jti, expiresInSec = JWT_EXPIRES_IN) {
   const { current } = getActiveKeys();
   return jwt.sign(
     { sub: user.id, id: user.id, username: user.username, role: user.role, jti },
     current,
-    { expiresIn: JWT_EXPIRES_IN, algorithm: 'HS256' }
+    { expiresIn: expiresInSec, algorithm: 'HS256' }
   );
 }
 

--- a/server/auth.test.js
+++ b/server/auth.test.js
@@ -200,6 +200,17 @@ describe('validatePassword + bcrypt (AC2)', () => {
     expect(await auth.validatePassword('nobody', 'whatever')).toBeNull();
   });
 
+  it('runs a bcrypt compare on the absent-user path (no enumeration timing oracle) (HLCE-285)', async () => {
+    const auth = await loadAuth();
+    await auth.createUser({ username: 'alice', password: 'correct horse' });
+    // The unknown-user branch must still pay the bcrypt cost so its timing
+    // matches the known-user path. Spy on bcrypt.compare and assert it ran.
+    const spy = vi.spyOn(bcrypt, 'compare');
+    expect(await auth.validatePassword('ghost-user', 'whatever')).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
   it('never stores the plaintext password (stored value is a bcrypt hash)', async () => {
     const auth = await loadAuth();
     await auth.createUser({ username: 'alice', password: 'secretpw' });

--- a/server/routes/auth-admin.js
+++ b/server/routes/auth-admin.js
@@ -232,7 +232,11 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
     if (!u || typeof u !== 'string' || !/^[a-z0-9._-]{3,32}$/.test(u)) return res.status(400).json({ ok: false });
     if (!['viewer', 'scanner'].includes(role)) return res.status(400).json({ ok: false });
     if (ttl_s < 60 || ttl_s > 3600) return res.status(400).json({ ok: false });
-    const token = generateToken({ id: u, username: u, role }, 'mint-' + crypto.randomBytes(8).toString('hex'));
+    // Mint a stateless, jti-less token: verifyToken only consults the sessions
+    // table when a jti is present, so a minted CLI token (no session row) must
+    // omit it or it would always 401. Its lifetime IS the requested ttl_s — the
+    // JWT's real `exp` is what enforces revocation here (no server-side session).
+    const token = generateToken({ id: u, username: u, role }, undefined, ttl_s);
     audit({ actor: u, ip: req.ip, event: 'auth.cli_mint', result: 'ok', meta: { role, ttl_s } });
     res.json({ a: token, exp: Math.floor(Date.now() / 1000) + ttl_s });
   });

--- a/server/routes/auth-admin.routes.test.js
+++ b/server/routes/auth-admin.routes.test.js
@@ -202,6 +202,30 @@ describe('cli-mint token endpoint (AC4)', () => {
     expect((await request(app).post('/auth/cli-mint').set('X-Mint-Key', key).send({ u: 'scanbot', ttl_s: 10 })).status).toBe(400);
     expect((await request(app).post('/auth/cli-mint').set('X-Mint-Key', key).send({ u: 'scanbot', ttl_s: 99999 })).status).toBe(400);
   });
+
+  it('a minted token actually authenticates a protected route and honors ttl_s (HLCE-285)', async () => {
+    const key = process.env.CLI_MINT_KEY;
+    const ttl = 600;
+    const before = Math.floor(Date.now() / 1000);
+    const mint = await request(app).post('/auth/cli-mint')
+      .set('X-Mint-Key', key).send({ u: 'scanbot', role: 'scanner', ttl_s: ttl });
+    expect(mint.status).toBe(200);
+    const token = mint.body.a;
+
+    // Previously the route stamped a jti that was never written to the sessions
+    // table, so verifyToken's isJtiActive check failed and every minted token
+    // 401'd. The token must now authenticate a requireAuth-gated route.
+    const me = await request(app).get('/auth/me/stars').set('Cookie', `hl_session=${token}`);
+    expect(me.status).toBe(200);
+    expect(Array.isArray(me.body.stars)).toBe(true);
+
+    // The JWT's real `exp` reflects the requested ttl_s (not the hardcoded 900s).
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+    expect(payload.exp).toBeGreaterThanOrEqual(before + ttl - 2);
+    expect(payload.exp).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + ttl + 2);
+    // A jti-less token is exactly what makes it verifiable without a session row.
+    expect(payload.jti).toBeUndefined();
+  });
 });
 
 describe('internal audit token endpoint (AC4)', () => {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -376,7 +376,10 @@ export default function authRoutes({ sendError, getRequestMeta, loginLimiter, lo
   // R3: MFA disable — requires password confirmation
   router.post('/auth/mfa/disable', requireAuth, async (req, res) => {
     try {
-      const { password } = req.body;
+      const { password } = req.body || {};
+      if (typeof password !== 'string' || password.length === 0) {
+        return res.status(400).json({ error: 'Password required' });
+      }
       const userId = req.user.sub || req.user.id;
       const user = findUserById(userId);
       if (!user) return res.status(404).json({ error: 'User not found' });

--- a/server/routes/auth.routes.test.js
+++ b/server/routes/auth.routes.test.js
@@ -172,6 +172,24 @@ describe('MFA-gated login (AC2)', () => {
     const none = await request(app).post('/auth/login/mfa').send({ code: '000000' });
     expect(none.status).toBe(400);
   });
+
+  it('a login ticket is single-use — a second /auth/login/mfa with the same ticket → 401 (HLCE-285)', async () => {
+    // The ticket is consumed on the FIRST /auth/login/mfa call regardless of
+    // whether the code was valid; replaying it must 401. This throttles TOTP
+    // brute force: each guess needs a fresh password round-trip to mint a ticket.
+    await auth.createUser({ username: 'mfaonce', email: 'mo@x.com', password: 'mfapass12', role: 'user' });
+    const { totp } = await enableMfa('mfaonce');
+    const t = await request(app).post('/auth/login').send({ username: 'mfaonce', password: 'mfapass12' });
+    const ticket = t.body.ticket;
+    expect(ticket).toBeTruthy();
+
+    const first = await request(app).post('/auth/login/mfa').send({ ticket, code: totp.generate() });
+    expect(first.status).toBe(200);
+
+    // Same ticket again — already consumed → 401 even with a valid current code.
+    const replay = await request(app).post('/auth/login/mfa').send({ ticket, code: totp.generate() });
+    expect(replay.status).toBe(401);
+  });
 });
 
 describe('refresh rotation & reuse detection (AC2)', () => {
@@ -339,5 +357,29 @@ describe('MFA setup / verify / disable (AC2-adjacent)', () => {
     const disabled = await hdrs2(agent.post('/auth/mfa/disable')).send({ password: 'mfaflowpass' });
     expect(disabled.status).toBe(200);
     expect(disabled.body.disabled).toBe(true);
+  });
+
+  it('MFA enroll is session-gated while disable additionally requires the password (HLCE-285)', async () => {
+    // Documents the intentional asymmetry: setup/verify only need a live session
+    // (you are already authenticated, so adding a second factor is low-risk),
+    // but disabling a factor weakens the account and must re-prove the password.
+    // Enroll endpoints reject an unauthenticated caller (session gate).
+    expect((await request(app).post('/auth/mfa/setup')).status).toBe(401);
+    expect((await request(app).post('/auth/mfa/verify').send({ code: '123456' })).status).toBe(401);
+    // Disable is session-gated too...
+    expect((await request(app).post('/auth/mfa/disable').send({ password: 'whatever' })).status).toBe(401);
+
+    // ...and even WITH a session, disable rejects a missing/wrong password (4xx),
+    // whereas setup with a session succeeds without any password.
+    await auth.createUser({ username: 'mfagate', email: 'mg@x.com', password: 'mfagatepass', role: 'user' });
+    const { agent, csrf } = await login('mfagate', 'mfagatepass');
+    const hdrs = (r) => r.set('x-csrf-token', csrf).set('x-requested-with', 'XMLHttpRequest');
+
+    // setup needs only the session.
+    expect((await hdrs(agent.post('/auth/mfa/setup'))).status).toBe(200);
+    // disable without a password is rejected (4xx — not a successful disable).
+    const noPw = await hdrs(agent.post('/auth/mfa/disable')).send({});
+    expect(noPw.status).toBeGreaterThanOrEqual(400);
+    expect(noPw.status).toBeLessThan(500);
   });
 });


### PR DESCRIPTION
Part of HLCE-279 adversarial-review remediation epic.

## What changed
- **cli-mint** (`auth-admin.js`): mints a *stateless, jti-less* token honoring the requested `ttl_s` (60–3600s). Previously minted tokens carried no session row so `verifyToken` 401'd them; `generateToken` now takes an optional `expiresInSec` (default 900s — all other callers unchanged).
- **validatePassword** (`auth.js`): runs `bcrypt.compare` against a `DUMMY_PASSWORD_HASH` on the absent-user path, removing the user-enumeration timing oracle.
- **MFA invariants** (`auth.js`/`auth.js` routes): single-use ticket + enroll/disable pins; `POST /auth/mfa/disable` now returns **400** (was a 500 from `bcrypt.compare(undefined, hash)`) when password is missing.

## Verification
- `npm run test:coverage` exit 0, **887 tests pass**
- tsc clean, lint 0 errors
- jti-less minted token authenticates a protected route; absent-user path is constant-time
- no node_modules / index.js / CHANGELOG / vite.config.ts changes