### PR TITLE
HLCE-284: track Docker/SSE timers, fix health lie, lock down SSE CORS + subscribe auth

### DIFF
--- a/server/cli-bridge.js
+++ b/server/cli-bridge.js
@@ -4,7 +4,7 @@ import path from 'path';
 import yaml from 'yaml';
 import { DeploymentLogger } from './deployment-logger.js';
 
-function safeJoin(base, ...parts) {
+export function safeJoin(base, ...parts) {
   for (const p of parts) {
     if (typeof p !== 'string' || !/^[a-z0-9][a-z0-9_.-]{0,63}$/i.test(p)) {
       throw new Error(`Invalid path component: ${JSON.stringify(p)}`);

--- a/server/docker-manager.js
+++ b/server/docker-manager.js
@@ -37,6 +37,20 @@ const logger = {
   }
 };
 
+// Error codes/markers that mean "the Docker daemon is not reachable" (as opposed
+// to the daemon answering with an application-level error like a 404). Used by the
+// CLI manager's executeWithRetry to keep its reachability state honest (HLCE-284).
+const CONNECTION_ERROR_CODES = new Set([
+  'ENOENT', 'ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EHOSTUNREACH', 'ENETUNREACH'
+]);
+
+function isConnectionError(error) {
+  if (!error) return false;
+  if (error.code && CONNECTION_ERROR_CODES.has(error.code)) return true;
+  const msg = typeof error.message === 'string' ? error.message : '';
+  return /ECONNREFUSED|ECONNRESET|ENOENT|EPIPE|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|connect|socket|not reachable/i.test(msg);
+}
+
 class DockerConnectionManager {
   constructor(options = {}) {
     const dockerConfig = EnvironmentManager.getDockerConfig();
@@ -75,6 +89,8 @@ class DockerConnectionManager {
     this.healthCheckTimer = null;
     this.retryTimer = null;
     this.statsLogTimer = null;
+    this.halfOpenTimer = null;
+    this.connectionTestTimer = null;
 
     // Log initialization with platform-specific context
     logger.dockerConnection('info', 'Initializing Docker Connection Manager', {
@@ -309,13 +325,29 @@ class DockerConnectionManager {
         // Test the connection by listing containers with detailed logging
         logger.dockerConnection('debug', 'Testing Docker connection with container list operation');
 
-        // Add timeout to prevent hanging on modem errors
+        // Add timeout to prevent hanging on modem errors. Track the handle so it
+        // can be cleared in the finally below — an untracked 5s timer would keep
+        // the event loop alive and reject after the connection already resolved
+        // (HLCE-284).
         const testPromise = this.docker.listContainers({ limit: 1 });
-        const timeoutPromise = new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Docker connection test timeout')), 5000)
-        );
+        const timeoutPromise = new Promise((_, reject) => {
+          this.connectionTestTimer = setTimeout(
+            () => reject(new Error('Docker connection test timeout')),
+            5000
+          );
+          if (typeof this.connectionTestTimer.unref === 'function') {
+            this.connectionTestTimer.unref();
+          }
+        });
 
-        testResult = await Promise.race([testPromise, timeoutPromise]);
+        try {
+          testResult = await Promise.race([testPromise, timeoutPromise]);
+        } finally {
+          if (this.connectionTestTimer) {
+            clearTimeout(this.connectionTestTimer);
+            this.connectionTestTimer = null;
+          }
+        }
 
         logger.dockerConnection('debug', 'Docker connection test successful', {
           testContainers: testResult.length
@@ -511,6 +543,13 @@ class DockerConnectionManager {
     this.circuitBreaker.nextAttemptTime = null;
     this.circuitBreaker.state = 'CLOSED';
 
+    // The breaker closed cleanly, so the pending OPEN→HALF_OPEN transition is
+    // moot — clear its timer instead of leaving it to fire later (HLCE-284).
+    if (this.halfOpenTimer) {
+      clearTimeout(this.halfOpenTimer);
+      this.halfOpenTimer = null;
+    }
+
     if (previousState !== 'CLOSED' || previousFailures > 0) {
       logger.dockerConnection('info', 'Circuit breaker reset after successful connection', {
         previousState,
@@ -531,8 +570,14 @@ class DockerConnectionManager {
       timeoutDuration: this.config.circuitBreakerTimeout
     });
 
-    // Schedule circuit breaker to transition to HALF_OPEN
-    setTimeout(() => {
+    // Schedule circuit breaker to transition to HALF_OPEN. Track the handle so
+    // destroy() can clear it — an untracked timer keeps the event loop alive and
+    // can fire against a torn-down manager (HLCE-284).
+    if (this.halfOpenTimer) {
+      clearTimeout(this.halfOpenTimer);
+    }
+    this.halfOpenTimer = setTimeout(() => {
+      this.halfOpenTimer = null;
       if (this.circuitBreaker.state === 'OPEN') {
         this.circuitBreaker.state = 'HALF_OPEN';
         logger.dockerConnection('info', 'Circuit breaker transitioned to HALF_OPEN', {
@@ -541,6 +586,7 @@ class DockerConnectionManager {
         });
       }
     }, this.config.circuitBreakerTimeout);
+    if (typeof this.halfOpenTimer.unref === 'function') this.halfOpenTimer.unref();
   }
 
   canAttemptConnection() {
@@ -1077,7 +1123,9 @@ class DockerConnectionManager {
       timersCleared: {
         healthCheck: !!this.healthCheckTimer,
         retry: !!this.retryTimer,
-        statsLog: !!this.statsLogTimer
+        statsLog: !!this.statsLogTimer,
+        halfOpen: !!this.halfOpenTimer,
+        connectionTest: !!this.connectionTestTimer
       }
     });
 
@@ -1097,6 +1145,18 @@ class DockerConnectionManager {
       clearInterval(this.statsLogTimer);
       this.statsLogTimer = null;
       logger.dockerConnection('debug', 'Statistics logging timer cleared');
+    }
+
+    if (this.halfOpenTimer) {
+      clearTimeout(this.halfOpenTimer);
+      this.halfOpenTimer = null;
+      logger.dockerConnection('debug', 'Circuit-breaker half-open timer cleared');
+    }
+
+    if (this.connectionTestTimer) {
+      clearTimeout(this.connectionTestTimer);
+      this.connectionTestTimer = null;
+      logger.dockerConnection('debug', 'Connection-test timer cleared');
     }
 
     // Log final state change
@@ -1187,11 +1247,24 @@ function createDockerManager() {
       return { status: 'unknown', message: 'Docker connection state not yet determined' };
     },
     executeWithRetry: async (operation, _description) => {
-      const result = await operation(cliDocker);
-      // A completed operation is positive proof the daemon is reachable.
-      state.isConnected = true;
-      state.lastSuccessfulConnection = new Date();
-      return result;
+      try {
+        const result = await operation(cliDocker);
+        // A completed operation is positive proof the daemon is reachable.
+        state.isConnected = true;
+        state.lastSuccessfulConnection = new Date();
+        return result;
+      } catch (error) {
+        // A connection-class failure is proof the daemon is NOT reachable. Mark
+        // the manager disconnected so getServiceStatus() stops reporting healthy
+        // — leaving isConnected:true after a throw was a partial health lie
+        // (HLCE-284). Non-connection errors (e.g. a 404 from the daemon) leave
+        // the reachability state untouched and just rethrow.
+        if (isConnectionError(error)) {
+          state.isConnected = false;
+          state.lastError = error;
+        }
+        throw error;
+      }
     },
     createErrorResponse: (operation, error, includeDetails = true) => ({
       success: false,

--- a/server/docker-manager.test.js
+++ b/server/docker-manager.test.js
@@ -269,4 +269,70 @@ describe('destroy clears timers (AC5)', () => {
     expect(m.statsLogTimer).toBeNull();
     expect(m.state.isConnected).toBe(false);
   });
+
+  // HLCE-284 (fix 1): the circuit-breaker OPEN→HALF_OPEN setTimeout was never
+  // tracked, so it kept the event loop alive and could fire against a torn-down
+  // manager. It is now stored on this.halfOpenTimer and cleared by destroy().
+  it('tracks the half-open timer when the breaker opens and clears it on destroy', () => {
+    const m = makeManager({ circuitBreakerThreshold: 1, circuitBreakerTimeout: 60000 });
+    expect(m.halfOpenTimer).toBeNull();
+
+    m.openCircuitBreaker();
+    expect(m.circuitBreaker.state).toBe('OPEN');
+    expect(m.halfOpenTimer).not.toBeNull(); // tracked, was untracked before fix
+
+    m.destroy();
+    expect(m.halfOpenTimer).toBeNull();
+  });
+
+  // HLCE-284 (fix 1): a clean close cancels the pending OPEN→HALF_OPEN timer
+  // instead of letting it fire later.
+  it('clears the half-open timer when the breaker closes on success', () => {
+    const m = makeManager({ circuitBreakerThreshold: 1, circuitBreakerTimeout: 60000 });
+    m.openCircuitBreaker();
+    expect(m.halfOpenTimer).not.toBeNull();
+
+    m.updateCircuitBreakerOnSuccess();
+    expect(m.circuitBreaker.state).toBe('CLOSED');
+    expect(m.halfOpenTimer).toBeNull();
+  });
+});
+
+// HLCE-284 (fix 2): the production CLI manager's executeWithRetry set
+// isConnected:true on success but never isConnected:false when an op threw a
+// connection-class error — a partial health lie (getServiceStatus stayed
+// 'available' over a dead socket). It now marks the manager unavailable on a
+// connection-class throw.
+describe('createDockerManager.executeWithRetry connection-class failure (fix 2)', () => {
+  it('marks the daemon unavailable when an op throws a connection error', async () => {
+    const m = createDockerManager();
+    // Prime it healthy first.
+    m.docker.ping = vi.fn().mockResolvedValue('OK');
+    await m.probe();
+    expect(m.getServiceStatus()).toMatchObject({ status: 'available' });
+
+    const connErr = new Error('connect ENOENT /var/run/docker.sock');
+    connErr.code = 'ENOENT';
+    await expect(m.executeWithRetry(() => Promise.reject(connErr), 'list')).rejects.toThrow(/ENOENT/);
+
+    // No longer a lie: status reflects the failed connection.
+    expect(m.getServiceStatus()).toMatchObject({ status: 'unavailable' });
+    expect(m.getConnectionState()).toMatchObject({ isConnected: false });
+    m.destroy();
+  });
+
+  it('leaves reachability untouched for a non-connection (application) error', async () => {
+    const m = createDockerManager();
+    m.docker.ping = vi.fn().mockResolvedValue('OK');
+    await m.probe();
+    expect(m.getServiceStatus()).toMatchObject({ status: 'available' });
+
+    const appErr = new Error('no such container'); // daemon answered → reachable
+    appErr.statusCode = 404;
+    await expect(m.executeWithRetry(() => Promise.reject(appErr), 'inspect')).rejects.toThrow(/no such container/);
+
+    // Daemon answered, so reachability is unchanged.
+    expect(m.getServiceStatus()).toMatchObject({ status: 'available' });
+    m.destroy();
+  });
 });

--- a/server/progress-stream.js
+++ b/server/progress-stream.js
@@ -20,8 +20,14 @@ export function resolveAllowedOrigin(origin) {
     return null;
   }
   const allowed = Array.isArray(allow) ? allow : [allow];
-  if (allowed.includes('*')) return origin; // dev wildcard: reflect, never emit '*'
-  return allowed.includes(origin) ? origin : null;
+  // Echo the matching entry FROM the configured allowlist rather than the
+  // request-supplied Origin, so the untrusted request value never flows into
+  // the credentialed ACAO header (js/cors-misconfiguration-for-credentials).
+  // A bare '*' is intentionally NOT honored here: reflecting an arbitrary
+  // origin alongside Access-Control-Allow-Credentials is a credential leak
+  // (CWE-942). Same-origin dev traffic carries no Origin header and needs no
+  // ACAO; any cross-origin client must be explicitly allowlisted in corsOrigin.
+  return allowed.find((entry) => entry === origin) ?? null;
 }
 
 /**

--- a/server/progress-stream.js
+++ b/server/progress-stream.js
@@ -5,29 +5,30 @@ import { DeploymentLogger } from './deployment-logger.js';
 import { parseAppId, safeJoin } from './cli-bridge.js';
 
 /**
+ * The configured CORS allowlist as an array (empty when unset/unreadable).
+ * A bare `*` is intentionally NOT expanded here: this stream is credentialed,
+ * and reflecting an arbitrary origin alongside Access-Control-Allow-Credentials
+ * is a credential leak (CWE-942 / js/cors-misconfiguration-for-credentials).
+ * Cross-origin clients must be listed explicitly in corsOrigin.
+ */
+export function getCorsAllowlist() {
+  try {
+    const allow = EnvironmentManager.getConfiguration().corsOrigin;
+    return Array.isArray(allow) ? allow : [allow];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Return the request's Origin only when it is in the configured CORS allowlist.
  * Used to reflect a validated origin on the credentialed SSE stream instead of a
- * wildcard `*` (a wildcard is invalid with credentials and leaks the stream to
- * any origin — HLCE-284). Returns null for a same-origin request (no Origin
- * header) or a disallowed origin, in which case no ACAO header is sent.
+ * wildcard `*`. Returns null for a same-origin request (no Origin header) or a
+ * disallowed origin, in which case no ACAO header is sent.
  */
 export function resolveAllowedOrigin(origin) {
   if (!origin) return null;
-  let allow;
-  try {
-    allow = EnvironmentManager.getConfiguration().corsOrigin;
-  } catch {
-    return null;
-  }
-  const allowed = Array.isArray(allow) ? allow : [allow];
-  // Echo the matching entry FROM the configured allowlist rather than the
-  // request-supplied Origin, so the untrusted request value never flows into
-  // the credentialed ACAO header (js/cors-misconfiguration-for-credentials).
-  // A bare '*' is intentionally NOT honored here: reflecting an arbitrary
-  // origin alongside Access-Control-Allow-Credentials is a credential leak
-  // (CWE-942). Same-origin dev traffic carries no Origin header and needs no
-  // ACAO; any cross-origin client must be explicitly allowlisted in corsOrigin.
-  return allowed.find((entry) => entry === origin) ?? null;
+  return getCorsAllowlist().includes(origin) ? origin : null;
 }
 
 /**
@@ -64,11 +65,12 @@ export class ProgressStreamManager extends EventEmitter {
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
     // Reflect a validated origin on this credentialed stream instead of a
-    // wildcard (HLCE-284). A wildcard is both invalid with credentials and an
-    // open door; same-origin requests carry no Origin header and need no ACAO.
-    const allowedOrigin = resolveAllowedOrigin(req?.headers?.origin);
-    if (allowedOrigin) {
-      res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
+    // wildcard (HLCE-284). The allowlist membership check sits inline at the
+    // sink so the request Origin is only echoed after passing it; same-origin
+    // requests carry no Origin header and need no ACAO.
+    const reqOrigin = req?.headers?.origin;
+    if (reqOrigin && getCorsAllowlist().includes(reqOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', reqOrigin);
       res.setHeader('Vary', 'Origin');
       res.setHeader('Access-Control-Allow-Credentials', 'true');
     }

--- a/server/progress-stream.js
+++ b/server/progress-stream.js
@@ -1,12 +1,27 @@
 import { EventEmitter } from 'events';
 import fs from 'fs';
-import path from 'path';
+import { EnvironmentManager } from './environment-manager.js';
 import { DeploymentLogger } from './deployment-logger.js';
-import { parseAppId } from './cli-bridge.js';
+import { parseAppId, safeJoin } from './cli-bridge.js';
 
-function sanitizePathComponent(input) {
-  if (!input || typeof input !== 'string') return '';
-  return input.replace(/[\/\\\.]{2,}/g, '').replace(/[\/\\\0]/g, '').replace(/^\.+/, '');
+/**
+ * Return the request's Origin only when it is in the configured CORS allowlist.
+ * Used to reflect a validated origin on the credentialed SSE stream instead of a
+ * wildcard `*` (a wildcard is invalid with credentials and leaks the stream to
+ * any origin — HLCE-284). Returns null for a same-origin request (no Origin
+ * header) or a disallowed origin, in which case no ACAO header is sent.
+ */
+export function resolveAllowedOrigin(origin) {
+  if (!origin) return null;
+  let allow;
+  try {
+    allow = EnvironmentManager.getConfiguration().corsOrigin;
+  } catch {
+    return null;
+  }
+  const allowed = Array.isArray(allow) ? allow : [allow];
+  if (allowed.includes('*')) return origin; // dev wildcard: reflect, never emit '*'
+  return allowed.includes(origin) ? origin : null;
 }
 
 /**
@@ -17,7 +32,9 @@ export class ProgressStreamManager extends EventEmitter {
   constructor() {
     super();
     this.clients = new Map(); // Map of clientId -> response object
+    this.clientOwners = new Map(); // Map of clientId -> owning session id (HLCE-284)
     this.deploymentStreams = new Map(); // Map of deploymentId -> client list
+    this.cleanupTimers = new Map(); // Map of deploymentId -> 30s cleanup timeout (HLCE-284)
     
     DeploymentLogger.logNetworkActivity('Progress Stream Manager initialized', {
       level: 'info',
@@ -28,14 +45,27 @@ export class ProgressStreamManager extends EventEmitter {
   /**
    * Add a new SSE client
    */
-  addClient(clientId, res) {
+  addClient(clientId, res, req = null) {
+    // Bind this client to the authenticated session that opened it (HLCE-284) so
+    // subscribeToDeployment can verify ownership and a client can't subscribe a
+    // stream it doesn't own. Falls back to null when no session info is present.
+    const ownerSessionId = req?.user?.id ?? req?.sessionId ?? null;
     this.clients.set(clientId, res);
-    
+    this.clientOwners.set(clientId, ownerSessionId);
+
     // Set up SSE headers
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect a validated origin on this credentialed stream instead of a
+    // wildcard (HLCE-284). A wildcard is both invalid with credentials and an
+    // open door; same-origin requests carry no Origin header and need no ACAO.
+    const allowedOrigin = resolveAllowedOrigin(req?.headers?.origin);
+    if (allowedOrigin) {
+      res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
+      res.setHeader('Vary', 'Origin');
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+    }
     res.setHeader('Access-Control-Allow-Headers', 'Cache-Control');
 
     // Send initial connection event with the server-assigned clientId
@@ -71,7 +101,8 @@ export class ProgressStreamManager extends EventEmitter {
     }
     
     this.clients.delete(clientId);
-    
+    this.clientOwners.delete(clientId);
+
     // Remove from deployment streams
     for (const [deploymentId, clients] of this.deploymentStreams.entries()) {
       const index = clients.indexOf(clientId);
@@ -93,9 +124,22 @@ export class ProgressStreamManager extends EventEmitter {
   /**
    * Subscribe client to a deployment stream
    */
-  subscribeToDeployment(clientId, deploymentId) {
+  subscribeToDeployment(clientId, deploymentId, requestingSessionId = undefined) {
     if (!this.clients.has(clientId)) {
       throw new Error(`Client ${clientId} not found`);
+    }
+
+    // Scope a subscription to the session that owns the client stream (HLCE-284).
+    // Without this, any caller could subscribe an arbitrary clientId — including
+    // another user's stream — to a deployment. When a requesting session is
+    // supplied it MUST match the client's recorded owner.
+    if (requestingSessionId !== undefined) {
+      const ownerSessionId = this.clientOwners.get(clientId) ?? null;
+      if (ownerSessionId !== requestingSessionId) {
+        const err = new Error(`Client ${clientId} is not owned by the requesting session`);
+        err.code = 'SUBSCRIBE_FORBIDDEN';
+        throw err;
+      }
     }
 
     if (!this.deploymentStreams.has(deploymentId)) {
@@ -210,10 +254,26 @@ export class ProgressStreamManager extends EventEmitter {
       completedAt: new Date().toISOString()
     });
 
-    // Clean up deployment stream after a delay
-    setTimeout(() => {
+    // Clean up deployment stream after a delay. Track the handle so it can be
+    // cleared (e.g. in destroy) and never keeps the event loop alive (HLCE-284).
+    const prior = this.cleanupTimers.get(deploymentId);
+    if (prior) clearTimeout(prior);
+    const timer = setTimeout(() => {
       this.deploymentStreams.delete(deploymentId);
+      this.cleanupTimers.delete(deploymentId);
     }, 30000); // Keep for 30 seconds for any late clients
+    if (typeof timer.unref === 'function') timer.unref();
+    this.cleanupTimers.set(deploymentId, timer);
+  }
+
+  /**
+   * Clear all pending cleanup timers (test teardown / shutdown).
+   */
+  destroy() {
+    for (const timer of this.cleanupTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.cleanupTimers.clear();
   }
 
   /**
@@ -287,8 +347,10 @@ export class StreamingCLIBridge {
       );
 
       const { category, appName } = parseAppId(appId);
-      const appPath = path.join(this.cliBridge.appsPath, sanitizePathComponent(category), `${sanitizePathComponent(appName)}.yml`);
-      
+      // Strict join: safeJoin REJECTS a bad/traversal component instead of
+      // silently stripping it like the old sanitizePathComponent (HLCE-284).
+      const appPath = safeJoin(this.cliBridge.appsPath, category, `${appName}.yml`);
+
       if (!fs.existsSync(appPath)) {
         throw new Error(`Application ${appId} not found at ${appPath}`);
       }

--- a/server/progress-stream.test.js
+++ b/server/progress-stream.test.js
@@ -8,7 +8,8 @@ import fs from 'node:fs';
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'x'.repeat(40);
 
-const { ProgressStreamManager, StreamingCLIBridge } = await import('./progress-stream.js');
+const { ProgressStreamManager, StreamingCLIBridge, resolveAllowedOrigin } = await import('./progress-stream.js');
+const { EnvironmentManager } = await import('./environment-manager.js');
 
 // HLCE-220: SSE progress stream + StreamingCLIBridge. ProgressStreamManager
 // writes SSE frames to a response object — we drive it with a fake `res`
@@ -16,10 +17,19 @@ const { ProgressStreamManager, StreamingCLIBridge } = await import('./progress-s
 // progressStream that records the emitted step/error/complete events.
 function fakeRes() {
   const r = new EventEmitter();
-  r.setHeader = vi.fn();
+  r.headers = {};
+  r.setHeader = vi.fn((k, v) => { r.headers[k] = v; });
   r.end = vi.fn();
   r.write = vi.fn(() => true);
   return r;
+}
+
+// A minimal Express-like request with an Origin header and an authenticated user.
+function fakeReq({ origin, userId } = {}) {
+  return {
+    headers: origin ? { origin } : {},
+    user: userId ? { id: userId } : undefined,
+  };
 }
 
 beforeEach(() => {
@@ -95,6 +105,54 @@ describe('ProgressStreamManager SSE fan-out (AC1)', () => {
     expect(c.write).toHaveBeenCalledWith('event: deployment-step\n');
   });
 
+  // HLCE-284 (fix 3a): the credentialed SSE stream used to hardcode
+  // Access-Control-Allow-Origin: '*', which is invalid with credentials and
+  // leaks the stream to any origin. It now reflects ONLY an allowlisted origin
+  // and never emits '*'.
+  it('never sets a wildcard ACAO and reflects only an allowlisted origin', () => {
+    vi.spyOn(EnvironmentManager, 'getConfiguration')
+      .mockReturnValue({ corsOrigin: ['https://ce-demo.homelabarr.com'] });
+    const mgr = new ProgressStreamManager();
+
+    const ok = fakeRes();
+    mgr.addClient('ok', ok, fakeReq({ origin: 'https://ce-demo.homelabarr.com' }));
+    expect(ok.headers['Access-Control-Allow-Origin']).toBe('https://ce-demo.homelabarr.com');
+    expect(ok.headers['Access-Control-Allow-Origin']).not.toBe('*');
+    expect(ok.headers['Access-Control-Allow-Credentials']).toBe('true');
+
+    const bad = fakeRes();
+    mgr.addClient('bad', bad, fakeReq({ origin: 'https://evil.example.com' }));
+    expect(bad.headers['Access-Control-Allow-Origin']).toBeUndefined();
+
+    const same = fakeRes(); // same-origin: no Origin header → no ACAO at all
+    mgr.addClient('same', same, fakeReq());
+    expect(same.headers['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+
+  it('resolveAllowedOrigin gates against the configured allowlist', () => {
+    vi.spyOn(EnvironmentManager, 'getConfiguration')
+      .mockReturnValue({ corsOrigin: ['https://a.test', 'https://b.test'] });
+    expect(resolveAllowedOrigin('https://a.test')).toBe('https://a.test');
+    expect(resolveAllowedOrigin('https://c.test')).toBeNull();
+    expect(resolveAllowedOrigin(undefined)).toBeNull();
+  });
+
+  // HLCE-284 (fix 3b): per-deployment authorization. A subscribe whose requesting
+  // session does not own the client must be REJECTED so a client can't subscribe
+  // to another session's stream.
+  it('rejects a subscribe from a session that does not own the client', () => {
+    const mgr = new ProgressStreamManager();
+    mgr.addClient('c-alice', fakeRes(), fakeReq({ userId: 'alice' }));
+
+    // Bob (session 'bob') tries to subscribe Alice's client → forbidden.
+    expect(() => mgr.subscribeToDeployment('c-alice', 'dep1', 'bob'))
+      .toThrow(/not owned/);
+
+    // The owning session succeeds.
+    expect(() => mgr.subscribeToDeployment('c-alice', 'dep1', 'alice')).not.toThrow();
+    expect(mgr.getStatistics()).toMatchObject({ activeDeployments: 1 });
+  });
+
   it('removeClient cleans up client + deployment subscriptions; getStatistics reflects state', () => {
     const mgr = new ProgressStreamManager();
     const a = fakeRes();
@@ -162,6 +220,43 @@ describe('StreamingCLIBridge.deployApplicationWithProgress (AC2)', () => {
     expect(stream.events).toContainEqual(expect.objectContaining({ kind: 'error' }));
     expect(stream.events).toContainEqual({ kind: 'complete', success: false });
     expect(bridge.getDeploymentStatus('dep2')).toMatchObject({ status: 'failed' });
+  });
+
+  // HLCE-284 (fix 4): the appId path used sanitizePathComponent (strip-not-reject),
+  // which silently swallowed traversal-ish components. It now routes through the
+  // strict safeJoin, which REJECTS a bad component instead of stripping it.
+  it('rejects a traversal-ish appId via strict safeJoin (not silently stripped)', async () => {
+    const existsSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const cli = { ...fakeCli(), appsPath: '/apps' };
+    const bridge = new StreamingCLIBridge(cli, fakeStream());
+
+    // parseAppId('media-../../etc/passwd') → appName '../../etc/passwd', which
+    // safeJoin rejects as an invalid path component.
+    await expect(
+      bridge.deployApplicationWithProgress('media-../../etc/passwd', {}, { type: 'standard' }, 'dep-bad'),
+    ).rejects.toThrow(/Invalid path component|Path traversal/);
+
+    // It never even got as far as the fs existence check / deploy.
+    expect(cli.deployStandard).not.toHaveBeenCalled();
+    existsSpy.mockRestore();
+  });
+
+  // HLCE-284 (fix 4): the 30s post-complete cleanup setTimeout is now tracked and
+  // cleared on destroy() so it can't leak / fire against a torn-down manager.
+  it('tracks the 30s cleanup timer and destroy() clears it', () => {
+    vi.useFakeTimers();
+    try {
+      const mgr = new ProgressStreamManager();
+      mgr.streamDeploymentComplete('dep-x', true, {});
+      expect(mgr.cleanupTimers.has('dep-x')).toBe(true);
+
+      mgr.destroy();
+      expect(mgr.cleanupTimers.size).toBe(0);
+      // No pending timers remain after destroy.
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('getActiveDeployments lists tracked deployments', async () => {

--- a/server/routes/deployments.js
+++ b/server/routes/deployments.js
@@ -34,7 +34,9 @@ export default function deploymentRoutes({ sendError, cliBridge, streamingCLIBri
   router.get('/stream/progress', requireAuth, (req, res) => {
     const clientId = randomUUID();
     try {
-      progressStream.addClient(clientId, res);
+      // Pass req so the stream can bind this client to the requesting session
+      // and reflect a validated CORS origin (HLCE-284).
+      progressStream.addClient(clientId, res, req);
       const stats = progressStream.getStatistics();
       progressStream.sendToClient(clientId, 'statistics', stats);
     } catch (error) {
@@ -49,9 +51,17 @@ export default function deploymentRoutes({ sendError, cliBridge, streamingCLIBri
       if (!clientId) {
         return res.status(400).json({ error: 'Client ID is required' });
       }
-      progressStream.subscribeToDeployment(clientId, deploymentId);
+      // Scope the subscription to the requesting session so a client can't
+      // subscribe to a stream it doesn't own (HLCE-284). When auth is enabled the
+      // session id is authoritative; with auth disabled it falls back to null,
+      // which matches the null owner recorded for anonymous streams.
+      const requestingSessionId = req.user?.id ?? req.sessionId ?? null;
+      progressStream.subscribeToDeployment(clientId, deploymentId, requestingSessionId);
       res.json({ success: true, message: `Subscribed to deployment ${deploymentId}`, deploymentId, clientId });
     } catch (error) {
+      if (error.code === 'SUBSCRIBE_FORBIDDEN') {
+        return res.status(403).json({ error: 'Not authorized to subscribe to this deployment stream' });
+      }
       sendError(res, 500, 'Failed to subscribe to deployment', error);
     }
   });

--- a/server/routes/deployments.routes.test.js
+++ b/server/routes/deployments.routes.test.js
@@ -118,7 +118,42 @@ describe('AC4 — POST /stream/deployments/:deploymentId/subscribe', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(progressStream.subscribeToDeployment).toHaveBeenCalledTimes(1);
-    expect(progressStream.subscribeToDeployment).toHaveBeenCalledWith('c-1', 'dep-1');
+    // HLCE-284: the route now scopes the subscription to the requesting session.
+    // With auth disabled (optionalAuth, no req.user) the session id is null.
+    expect(progressStream.subscribeToDeployment).toHaveBeenCalledWith('c-1', 'dep-1', null);
+  });
+
+  // HLCE-284: per-deployment authorization. When the stream rejects an
+  // unauthorized subscribe (client owned by a different session) the route must
+  // surface it as 403, not a generic 500.
+  it('returns 403 when the stream reports the client is not owned (SUBSCRIBE_FORBIDDEN)', async () => {
+    const progressStream = stubProgressStream();
+    progressStream.subscribeToDeployment.mockImplementation(() => {
+      const err = new Error('Client c-1 is not owned by the requesting session');
+      err.code = 'SUBSCRIBE_FORBIDDEN';
+      throw err;
+    });
+    const { app } = buildApp({ authEnabled: false, progressStream });
+
+    const res = await request(app)
+      .post('/stream/deployments/dep-1/subscribe')
+      .send({ clientId: 'c-1' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/Not authorized/);
+  });
+
+  it('passes the authenticated session id through to subscribeToDeployment', async () => {
+    const progressStream = stubProgressStream();
+    const { app } = buildApp({ authEnabled: true, progressStream });
+
+    const res = await request(app)
+      .post('/stream/deployments/dep-1/subscribe')
+      .set('Cookie', adminCookie())
+      .send({ clientId: 'c-1' });
+
+    expect(res.status).toBe(200);
+    expect(progressStream.subscribeToDeployment).toHaveBeenCalledWith('c-1', 'dep-1', 'u-admin');
   });
 
   it('rejects an unauthenticated subscribe with 401 when authEnabled wires requireAuth', async () => {


### PR DESCRIPTION
Part of HLCE-279 adversarial-review remediation epic.

## What changed
1. **Untracked timers** (`docker-manager.js`): HALF_OPEN circuit-breaker timer + 5s connection-test timer are now stored (`halfOpenTimer`/`connectionTestTimer`), `unref()`'d, and cleared in `destroy()`/on clean close/in `finally`. `progress-stream.js`: 30s post-complete cleanup timer tracked in `cleanupTimers` + cleared by `destroy()`.
2. **Partial health lie** (`docker-manager.js`): `executeWithRetry` now sets `isConnected=false`/`lastError` on a connection-class throw (new `isConnectionError` helper) before rethrowing; application errors (404) leave reachability untouched.
3. **SSE CORS + subscribe auth** (`progress-stream.js`/`deployments.js`): `addClient` no longer hardcodes `ACAO: *` — reflects only an allowlisted origin via `resolveAllowedOrigin` (from `corsOrigin` config). `subscribeToDeployment` scopes subscriptions to the owning session (`clientOwners`); mismatch throws `SUBSCRIBE_FORBIDDEN` → route maps to 403.
4. **Strict path gate** (`deployments.js`): appId routed through `safeJoin` (reject) instead of `sanitizePathComponent` (strip). `safeJoin` exported from `cli-bridge.js` (additive — `export` keyword only, no logic change).

## Verification
- `npm run test:coverage` exit 0, **898 tests pass**; tsc clean; lint 0 errors
- pinning tests verified to FAIL against original source; no node_modules / index.js / CHANGELOG / vite.config.ts changes
- independently confirmed: timers tracked+cleared, `isConnectionError` gates reachability, no wildcard ACAO remains, SUBSCRIBE_FORBIDDEN→403