### PR TITLE
HLCE-288: deploy.js outer catch is unreachable — trim dead branches + pin parser boundary

### DIFF
--- a/server/routes/dangerous-ops.routes.test.js
+++ b/server/routes/dangerous-ops.routes.test.js
@@ -1095,6 +1095,27 @@ describe('AC2/AC5 — deploy: streaming bridge, unsupported app, fallback, and s
     expect(silentLogger.error).toHaveBeenCalledWith('Streaming CLI deployment failed:', 'stream init failed');
     expect(silentLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Falling back to standard CLI'));
   });
+
+  // HLCE-288: pins the boundary that makes deploy.js's defensive outer catch
+  // unreachable via HTTP. express.json({ strict: true }) rejects a top-level
+  // non-object/array body (here a JSON `null`) with a 400 in body-parser BEFORE
+  // the handler runs — so the top-level destructure never throws, and since
+  // every other throwing path is wrapped in an inner try/catch, the outer catch
+  // can't be reached. The dockerManager is never touched, proving the request
+  // died at the parser rather than in the handler's catch.
+  it('rejects a non-object JSON body at the parser (400), never reaching the deploy handler', async () => {
+    const dockerManager = dockerManagerStub();
+    const { app } = buildApp({ dockerManager, cliBridge: null });
+    const res = await request(app)
+      .post('/deploy')
+      .set('Cookie', adminCookie())
+      .set('x-requested-with', 'XMLHttpRequest')
+      .set('Content-Type', 'application/json')
+      .send('null');
+    expect(res.status).toBe(400);
+    expect(dockerManager.createErrorResponse).not.toHaveBeenCalled();
+    expect(dockerManager.executeWithRetry).not.toHaveBeenCalled();
+  });
 });
 
 describe('AC5 — applications route supporting handlers', () => {

--- a/server/routes/deploy.js
+++ b/server/routes/deploy.js
@@ -200,27 +200,24 @@ export default function deployRoutes({
       // bridge, CLI bridge, or this 501). The former template-mode dockerode
       // deploy tail and the two duplicate it-tools blocks here were unreachable
       // dead code and were removed (HLCE-229).
+      /* v8 ignore start */
     } catch (error) {
-      logger.error(`❌ Failed to deploy ${appId}:`, error.message);
-
-      // Determine appropriate status code based on error type
-      let statusCode = 500;
-      if (error.dockerStatus === 'degraded') {
-        statusCode = 503;
-      } else if (error.message.includes('Port conflict')) {
-        statusCode = 409;
-      } else if (error.message.includes('Template not found')) {
-        statusCode = 404;
-      } else if (error.message.includes('required') || error.message.includes('invalid')) {
-        statusCode = 400;
-      }
-
+      // Defensive last-resort handler, UNREACHABLE via HTTP. express.json's
+      // strict mode rejects a non-object/array body with a 400 in body-parser
+      // before this handler runs, so the destructure above can't throw, and
+      // every other throwing path (it-tools spawn, streaming bridge, CLI
+      // bridge) is wrapped in its own inner try/catch. The old per-cause status
+      // branches here (503/409/404/400) mapped error shapes no reachable throw
+      // delivers — dead code that survived mutation (HLCE-277). Retained as a
+      // plain 500 so a future refactor that introduces an un-try'd throw fails
+      // safe instead of leaking an Express-4 unhandled rejection. The
+      // unreachable boundary is pinned by a body-parser 400 test (HLCE-288).
+      logger.error('❌ Deploy failed unexpectedly:', error?.message);
       const errorResponse = dockerManager.createErrorResponse('Deploy container', error);
-      errorResponse.appId = appId;
-      errorResponse.step = error.step || 'deployment';
-
-      res.status(statusCode).json(errorResponse);
+      errorResponse.step = error?.step || 'deployment';
+      res.status(500).json(errorResponse);
     }
+    /* v8 ignore stop */
   });
 
   return router;


### PR DESCRIPTION
Part of epic HLCE-286 (post-279 board cleanup).

## Corrected finding (AC1)
The outer `catch` in `POST /deploy` is **unreachable via HTTP**, not merely partially-dead as HLCE-277's note suggested:
- `express.json({ strict: true })` rejects a non-object/array body (e.g. JSON `null`) with a **400 in body-parser before the handler runs**, so the top-level destructure can't throw.
- Every other throwing path (it-tools spawn, streaming bridge, CLI bridge) is wrapped in its **own inner try/catch**.
- Therefore no reachable throw carries the `dockerStatus`/`Port conflict`/`Template not found`/`required` shapes the outer catch mapped — those four status branches were dead (surviving mutants).
- Bonus: the old catch referenced `appId`, which is `const`-scoped *inside* the try — so if it had ever fired it would have `ReferenceError`'d. Removed that reference.

## Change (AC2)
Trimmed the dead status-mapping to a plain defensive **500**, wrapped in `/* v8 ignore */` with a full justification. Kept as defensive depth so a future refactor introducing an un-try'd throw fails safe instead of leaking an Express-4 unhandled rejection — rather than deleting it.

## Test (AC3, reframed to the reachable boundary)
Added a test pinning the real boundary: a JSON `null` body → **400 at the parser**, with `dockerManager` never touched (proving the request dies before the handler's catch). This documents *why* the catch is unreachable.

## Verification (AC4)
- `npm run test:coverage` exit 0, **899 tests**; lint 0; deploy.js coverage 94.44% (the catch no longer counts as uncovered).
- No behavioral change to any reachable deploy path.