### PR TITLE
HLCE-287: document AUDIT_ANCHOR_KEY + out-of-band audit anchor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@
 # DEFAULT_ADMIN_PASSWORD=
 # ALERT_WEBHOOK_SECRET=
 # SQLCIPHER_KEY=
+# AUDIT_ANCHOR_KEY=   # optional — signs the out-of-band audit chain-tip anchor.
+                      # Defaults to JWT_SECRET if unset; set a dedicated key to
+                      # keep it independent of JWT key rotation.
 
 # ─── Non-secret configuration ───────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Found a vulnerability? Email **michael@mjashley.com** — see [SECURITY.md](SECU
 | `DOCKER_GID` | **Yes** | Docker group ID on your host. |
 | `CORS_ORIGIN` | **Yes** | The URL you open the dashboard at. |
 | `DEFAULT_ADMIN_PASSWORD` | Optional | Default is `admin` — change it. |
+| `AUDIT_ANCHOR_KEY` | Optional | Signs the audit log's out-of-band tamper-evidence anchor. Falls back to `JWT_SECRET` if unset. |
 | `TZ` | Optional | Your timezone. Defaults to `America/New_York`. |
 
 All options: [wiki.homelabarr.com/guides/configuration](https://wiki.homelabarr.com/guides/configuration/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -168,7 +168,7 @@ docker buildx imagetools inspect \
 1. **Read recent security events** — `GET /api/audit?limit=500` (requires admin auth)
 2. **Revoke all sessions** — `POST /api/auth/sessions/revoke-all` or directly: `sqlite3 /app/data/sessions.db "UPDATE sessions SET revoked_at = strftime('%s','now') * 1000 WHERE revoked_at IS NULL;"`
 3. **Rotate JWT_SECRET** — regenerate with `openssl rand -base64 48`, update the env, restart backend. All outstanding tokens become invalid.
-4. **Verify audit chain integrity** — `GET /api/audit` returns `chain.ok: true/false`
+4. **Verify audit chain integrity** — `GET /api/audit` returns `chain.ok: true/false`. The audit log is a per-row hash chain anchored two ways: an in-DB `audit_chain_tip` (detects tail truncation) and an **out-of-band, HMAC-signed anchor file** (`<AUDIT_DIR>/chain-tip.anchor`, signed with `AUDIT_ANCHOR_KEY`, falling back to `JWT_SECRET`). A `chain.ok: false` carries a `kind`: `prev_hash_mismatch`/`row_hash_mismatch`/`id_gap`/`tail_truncated` (in-DB tampering), or `anchor_mismatch`/`anchor_unsigned`/`anchor_unreadable` (the signed anchor disagrees with the DB — evidence of a full-DB rewrite by a privileged attacker). The anchor secret is **not** stored in the DB, so a DB-only compromise cannot forge it; keep the anchor file on storage the DB process can write but treat its deletion as a tamper signal.
 5. **Archive audit logs** — rotated JSONL files at `/app/server/activity-data/audit-*.jsonl.gz`
 
 ## Key Rotation Runbook

--- a/wiki/docs/guides/configuration.md
+++ b/wiki/docs/guides/configuration.md
@@ -26,6 +26,7 @@ Optional, but useful:
 | `BACKEND_PORT` | `8092` | Port for the API server |
 | `TZ` | `UTC` | Your timezone (e.g., `America/New_York`, `Europe/London`) |
 | `AUTH_ENABLED` | `true` | Set to `false` to disable the login screen |
+| `AUDIT_ANCHOR_KEY` | falls back to `JWT_SECRET` | Signs the tamper-evident audit log's out-of-band chain-tip anchor. Leave unset to reuse `JWT_SECRET`; set a dedicated random value (`openssl rand -hex 32`) to keep audit integrity independent of JWT key rotation. |
 
 !!! danger "Don't disable auth on a networked server"
     Setting `AUTH_ENABLED=false` removes the login screen and exposes all API endpoints — including container management and user administration — to anyone who can reach your server. Only use this in isolated local testing environments.


### PR DESCRIPTION
Docs-only follow-up completing HLCE-287's DoD (epic HLCE-286). The audit chain-tip anchor introduced an operator-facing env var (`AUDIT_ANCHOR_KEY`) and new `verifyChain()` result kinds that the CHANGELOG captured but the config docs did not.

- **README.md** — `AUDIT_ANCHOR_KEY` added to the env-var table (Optional, falls back to JWT_SECRET).
- **SECURITY.md** — incident-response audit-verification step now documents the dual anchoring (in-DB tip + out-of-band signed anchor) and all `chain.ok:false` kinds incl. `anchor_mismatch`/`anchor_unsigned`/`anchor_unreadable`.
- **.env.example** — `AUDIT_ANCHOR_KEY` in the Secrets block with the JWT_SECRET-fallback note.
- **wiki/docs/guides/configuration.md** — added to the Server Settings env-var table (republishes to wiki.homelabarr.com on merge).

No code/test changes.