### PR TITLE
HLCE-290: restore Trivy default-branch reporting

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -257,6 +257,7 @@ jobs:
     if: needs.changes.outputs.docker == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'schedule'
     permissions:
       contents: read
+      packages: read
       security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
@@ -291,6 +292,12 @@ jobs:
           echo "Images to scan:"; cat docker-images.txt
 
       - name: Scan HomelabARR container images
+        env:
+          # The frontend/backend images are private GHCR packages. Trivy's remote
+          # keychain reads these to authenticate the pull; without them the pull
+          # returns UNAUTHORIZED, Trivy FATALs, and no SARIF is produced.
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Scanning container images for vulnerabilities..."
           mkdir -p trivy-results
@@ -318,8 +325,20 @@ jobs:
             $HOME/.local/bin/trivy image --format sarif --output "trivy-results/trivy-$image_name.sarif" \
               --severity CRITICAL,HIGH \
               "$image" || true
-              
+
           done < docker-images.txt
+
+          # The trivy calls above swallow errors so a single CVE never fails the
+          # job — but that also hid a total auth failure (no SARIF for days).
+          # If nothing was produced, the scan really failed: surface it. Hard-fail
+          # only where a result MUST land on a ref (push to main / nightly / manual);
+          # PRs from forks lack package access, so leave those green.
+          if ! ls trivy-results/*.sarif >/dev/null 2>&1; then
+            echo "::error::Trivy produced no SARIF output — image pull or scan failed (check GHCR auth / image availability)"
+            if [ "${{ github.event_name }}" != "pull_request" ]; then
+              exit 1
+            fi
+          fi
 
       - name: Generate vulnerability summary
         run: |

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,7 +1,13 @@
 name: Security Audit and Compliance
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Nightly rescan so Trivy catches newly-disclosed CVEs in the unchanged
+    # :latest images and a fresh result lands on the default branch.
+    - cron: '37 4 * * *'
   workflow_dispatch:
     inputs:
       run_docker_scan:
@@ -245,7 +251,10 @@ jobs:
   docker-vulnerability-scan:
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.docker == 'true' || github.event_name == 'workflow_dispatch'
+    # On push to main and on the nightly schedule, always scan the published
+    # images so a fresh Trivy result lands on refs/heads/main regardless of
+    # which files changed (image CVEs appear independently of source changes).
+    if: needs.changes.outputs.docker == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'schedule'
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## What changed
- Added `push: branches: [main]` + a nightly `schedule` (`37 4 * * *`) to `security-audit.yml`.
- The `docker-vulnerability-scan` (Trivy) job now also runs on `push` and `schedule` events, regardless of which files changed.

## Why
Trivy produced **zero** code-scanning analyses on `refs/heads/main` since **2026-06-19T15:40**, while CodeQL (27) and Scorecard (73) kept reporting. The 2026-06-19 `security-audit.yml` rewrite (a) dropped the `push:[main]` trigger — workflow ran only on `pull_request` + `workflow_dispatch` — and (b) change-gated the Trivy job behind `needs.changes.outputs.docker == 'true'`. Net: Trivy fired only on the rare Docker-touching PR, attached to the PR ref, and never landed on `main`. The Trivy tool-status page read "stale" as a result. Its 5 historical alerts are all `fixed`; **0 open** — this was a reporting gap, not a live vuln.

## Effect
- Every merge to `main` now scans the published `:latest` frontend/backend images and uploads SARIF under `trivy-homelabarr-frontend` / `trivy-homelabarr-backend` on `refs/heads/main`.
- Nightly schedule catches newly-disclosed CVEs in the unchanged images.
- On `schedule` (no diff base), the other change-gated jobs skip; only the image scan runs.

## Verification
- [x] YAML parses (`yaml.safe_load`); triggers = push, pull_request, schedule, workflow_dispatch.
- [x] `changes` job runs unconditionally → `needs:[changes]` satisfied on push/schedule.
- [ ] After merge: a fresh Trivy analysis appears on `refs/heads/main` (`gh api .../code-scanning/analyses?ref=refs/heads/main&tool_name=Trivy`).
- [ ] Follow-up (AC5): delete the orphaned `trivy-image` category's stale analyses once the new categories report on main.

## Rollback
`git revert 02b911c` (single workflow-file commit).

Epic HLCE-289 · Story HLCE-290