### PR TITLE
HLCE-291: resolve open code-scanning alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: "HomelabARR CE CodeQL config"
+
+# Exclude generated/vendored JavaScript from SAST. wiki/site is the MkDocs
+# build output (committed to serve via Pages) and bundles the third-party lunr
+# search library — it is not our source and produced 37 noise alerts that
+# buried real findings. Also skip any minified bundles repo-wide.
+paths-ignore:
+  - wiki/site
+  - '**/*.min.js'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,7 @@ jobs:
           languages: javascript-typescript
           build-mode: none
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4

--- a/server/audit.js
+++ b/server/audit.js
@@ -104,8 +104,12 @@ export function initAudit() {
 function redact(obj) {
   if (!obj || typeof obj !== 'object') return obj;
   if (Array.isArray(obj)) return obj.map(redact);
+  // meta is request-supplied, so copying its keys onto a plain object lets a
+  // `__proto__`/`constructor` key poison the prototype. Skip those keys (audit
+  // meta never legitimately uses them); everything else copies through.
   const out = {};
   for (const [k, v] of Object.entries(obj)) {
+    if (k === '__proto__' || k === 'constructor' || k === 'prototype') continue;
     out[k] = REDACT_KEYS.test(k) ? '[REDACTED]' : (typeof v === 'object' ? redact(v) : v);
   }
   return out;

--- a/server/auth.js
+++ b/server/auth.js
@@ -3,11 +3,8 @@ import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { readSecret, readSecretFresh } from './secrets.js';
-import { createSession, isJtiActive, getSessionByJti, rotateRefresh, revokeSession, revokeAllForUser, listForUser } from './sessions.js';
-import { newTotp, verifyTotp, makeBackupCodes, hashBackupCodes, verifyBackupCode, getMfaForUser, saveMfaForUser, disableMfaForUser, setPendingMfa, getPendingMfa, clearPendingMfa } from './mfa.js';
-import transporter from './email.js';
-import QRCode from 'qrcode';
+import { readSecretFresh } from './secrets.js';
+import { createSession, isJtiActive } from './sessions.js';
 import { hkdfSync } from 'node:crypto';
 import { logger } from './log.js';
 
@@ -503,18 +500,29 @@ function saveResets(data) {
   fs.writeFileSync(RESET_FILE, JSON.stringify(data, null, 2));
 }
 
+// userId comes from request bodies (reset flow), so reject the prototype-poisoning
+// keys before using it as a property name on the resets map. A real user id never
+// matches these, so this only blocks abuse.
+function isSafeResetKey(userId) {
+  return typeof userId === 'string' && userId !== '__proto__'
+    && userId !== 'constructor' && userId !== 'prototype';
+}
+
 export function saveResetToken(userId, hash, exp) {
+  if (!isSafeResetKey(userId)) return;
   const all = loadResets();
   all[userId] = { hash, exp };
   saveResets(all);
 }
 
 export function getResetTokenForUser(userId) {
+  if (!isSafeResetKey(userId)) return null;
   const all = loadResets();
-  return all[userId] || null;
+  return Object.hasOwn(all, userId) ? all[userId] : null;
 }
 
 export function clearResetToken(userId) {
+  if (!isSafeResetKey(userId)) return;
   const all = loadResets();
   delete all[userId];
   saveResets(all);

--- a/server/deployment-logger.js
+++ b/server/deployment-logger.js
@@ -66,17 +66,33 @@ export class DeploymentLogger {
   }
 
   /**
+   * Strip CR/LF and other C0 control characters from a value before it is
+   * written to the console, so untrusted input cannot forge or split log
+   * entries (CodeQL js/log-injection). Tabs/newlines collapse to a space.
+   * @private
+   */
+  static #sanitizeForLog(value) {
+    // eslint-disable-next-line no-control-regex
+    return String(value).replace(/[\x00-\x1f\x7f]/g, ' ');
+  }
+
+  /**
    * Format and output a log entry
    * @private
    */
   static #outputLog(logEntry, emoji = '') {
     const { level, component, message, timestamp, ...context } = logEntry;
-    
-    // Create formatted message
-    const formattedMessage = `${emoji} [${component}] ${message}`;
-    
-    // Create context string if context exists
-    const contextStr = Object.keys(context).length > 0 ? 
+
+    // Create formatted message. message/component/context can carry untrusted
+    // values (CORS origins, request URLs, Docker error text), so neutralize
+    // CR/LF and other control chars before they reach the console to prevent
+    // forged log entries (CodeQL js/log-injection).
+    const formattedMessage = DeploymentLogger.#sanitizeForLog(`${emoji} [${component}] ${message}`);
+
+    // Create context string if context exists. JSON.stringify already escapes
+    // CR/LF and control chars inside string values to their \uXXXX/\n literals,
+    // so the only real newlines here are the pretty-print indentation — safe.
+    const contextStr = Object.keys(context).length > 0 ?
       '\n' + JSON.stringify(context, null, 2) : '';
 
     // Output based on log level

--- a/server/email.js
+++ b/server/email.js
@@ -1,5 +1,12 @@
 import nodemailer from 'nodemailer';
 
+// Neutralize CR/LF and other control chars before echoing mail fields to the
+// console, so a tainted recipient/subject/body (e.g. a forged Host header that
+// reaches the reset URL) cannot forge or split log entries (CodeQL
+// js/log-injection).
+// eslint-disable-next-line no-control-regex
+const stripLogControl = (v) => String(v).replace(/[\x00-\x1f\x7f]/g, ' ');
+
 let transporter;
 
 if (process.env.SMTP_HOST) {
@@ -12,8 +19,8 @@ if (process.env.SMTP_HOST) {
 } else {
   transporter = {
     sendMail: async (opts) => {
-      console.log('[email-stub] To:', opts.to, 'Subject:', opts.subject);
-      console.log('[email-stub] Body:', opts.text);
+      console.log('[email-stub] To:', stripLogControl(opts.to), 'Subject:', stripLogControl(opts.subject));
+      console.log('[email-stub] Body:', stripLogControl(opts.text));
       return { messageId: 'stub-' + Date.now() };
     },
   };

--- a/server/environment-manager.js
+++ b/server/environment-manager.js
@@ -1,6 +1,5 @@
 import os from 'os';
 import fs from 'fs';
-import path from 'path';
 
 /**
  * Environment Detection and Configuration Manager

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,6 @@
 import express from 'express';
 import cors from 'cors';
 import yaml from 'yaml';
-import fs from 'fs';
-import path from 'path';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import crypto from 'crypto';
@@ -12,7 +10,7 @@ import { initializeActivityLog, logActivity } from './activity-logger.js';
 import { initAudit, audit, verifyChain } from './audit.js';
 import { maybeAlert, setAuditHook } from './alert.js';
 import { logger as structuredLogger, requestContext } from './log.js';
-import { SqliteStore, createLoginLimiter, createLockoutGuard } from './ratelimit.js';
+import { createLoginLimiter, createLockoutGuard } from './ratelimit.js';
 import { attackTag } from './middleware/attackTag.js';
 import { mountHoney } from './routes/honey.js';
 import { EnvironmentManager } from './environment-manager.js';
@@ -20,7 +18,7 @@ import { NetworkManager } from './network-manager.js';
 import { DeploymentLogger } from './deployment-logger.js';
 import { CLIBridge } from './cli-bridge.js';
 import { progressStream, StreamingCLIBridge } from './progress-stream.js';
-import { DockerConnectionManager, createDockerManager } from './docker-manager.js';
+import { createDockerManager } from './docker-manager.js';
 
 import authRoutes from './routes/auth.js';
 import authAdminRoutes from './routes/auth-admin.js';
@@ -100,7 +98,21 @@ app.use((err, req, res, next) => {
 app.use(DeploymentLogger.createCorsLoggingMiddleware());
 app.use(cors(corsOptions));
 app.use(helmet({
-  contentSecurityPolicy: false,
+  // This is a JSON-only API behind the nginx frontend. nginx owns the CSP for
+  // the HTML/SPA routes (see nginx.conf.template) and deliberately does NOT add
+  // a CSP to proxied /api responses, so there is no duplicate-header concern
+  // (M-25). A locked-down "default-src 'none'" is the correct policy for API
+  // JSON responses — they load no scripts/styles/images — and is strictly safer
+  // than disabling CSP entirely.
+  contentSecurityPolicy: {
+    useDefaults: false,
+    directives: {
+      'default-src': ["'none'"],
+      'frame-ancestors': ["'none'"],
+      'base-uri': ["'none'"],
+      'form-action': ["'none'"],
+    },
+  },
   crossOriginEmbedderPolicy: false,
   crossOriginOpenerPolicy: { policy: 'same-origin' },
   crossOriginResourcePolicy: { policy: 'same-site' },
@@ -111,6 +123,11 @@ app.use((req, res, next) => {
   next();
 });
 app.use(cookieParser());
+// CSRF protection for cookie-session requests is enforced globally by the
+// mandatory double-submit middleware below (cookie hl_csrf vs x-csrf-token
+// header, timing-safe compare, XHR-required). CodeQL's js/missing-token-validation
+// cannot follow that custom global guard from this cookieParser() call — the
+// validation is present (false positive); see the CSRF middleware further down.
 app.use(requestContext);
 app.use(attackTag);
 mountHoney(app);
@@ -196,7 +213,7 @@ if (isDevelopment) {
 let unhandledRejectionCount = 0;
 let uncaughtExceptionCount = 0;
 
-const dockerManager = createDockerManager(networkConfig);
+const dockerManager = createDockerManager();
 
 const deps = {
   sendError, getRequestMeta, loginLimiter, lockout, authEnabled, isDevelopment,

--- a/server/network-manager.js
+++ b/server/network-manager.js
@@ -1,4 +1,3 @@
-import os from 'os';
 import fs from 'fs';
 import { EnvironmentManager } from './environment-manager.js';
 

--- a/server/progress-stream.js
+++ b/server/progress-stream.js
@@ -339,6 +339,16 @@ export class StreamingCLIBridge {
    * Deploy application with progress streaming
    */
   async deployApplicationWithProgress(appId, config, deploymentMode, deploymentId) {
+    // Normalize the caller-supplied deployment mode against a fixed allowlist so
+    // that the infrastructure-setup and dispatch decisions below are driven by a
+    // trusted, known value rather than raw request input (CodeQL
+    // js/user-controlled-bypass). Anything unrecognized falls back to 'standard',
+    // matching the existing switch default.
+    const SUPPORTED_MODES = ['traefik', 'local', 'standard', 'authelia'];
+    const requestedType = deploymentMode && deploymentMode.type;
+    const modeType = SUPPORTED_MODES.includes(requestedType) ? requestedType : 'standard';
+    deploymentMode = { ...deploymentMode, type: modeType };
+
     this.activeDeployments.set(deploymentId, {
       appId,
       startedAt: new Date().toISOString(),

--- a/server/routes/auth-admin.js
+++ b/server/routes/auth-admin.js
@@ -10,7 +10,6 @@ import {
   loadUsers,
   saveUsers,
   findUserByUsername,
-  findUserById,
   generateToken,
   createApiKey,
   listApiKeys,

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -2,7 +2,6 @@ import { Router } from 'express';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { execSync } from 'child_process';
 
 export default function healthRoutes({ requireAuth, requireRole, sendError, dockerManager, envConfig, networkConfig, EnvironmentManager, NetworkManager, DeploymentLogger, logger, isDevelopment, getProcessCounters }) {
   const router = Router();
@@ -25,23 +24,9 @@ export default function healthRoutes({ requireAuth, requireRole, sendError, dock
     const serviceStatus = dockerManager.getServiceStatus();
 
     try {
-      let dockerStatus = 'connected';
+      let dockerStatus;
       let dockerDetails = {};
       let dockerInfo = null;
-
-      const dockerHost = process.env.DOCKER_HOST;
-      if (dockerHost && dockerHost.startsWith('tcp://')) {
-        try {
-          const url = new URL(dockerHost.replace('tcp://', 'http://'));
-          const pingRes = await fetch(`http://${url.hostname}:${url.port}/_ping`, { signal: AbortSignal.timeout(2000) });
-          dockerStatus = pingRes.ok ? 'connected' : 'disconnected';
-        } catch { dockerStatus = 'disconnected'; }
-      } else {
-        try {
-          execSync('docker info --format "{{.ServerVersion}}"', { encoding: 'utf8', timeout: 5000 });
-          dockerStatus = 'connected';
-        } catch { dockerStatus = 'disconnected'; }
-      }
 
       if (connectionState.isConnected) {
         try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -745,16 +745,7 @@ export default function App() {
             </Button>
             <ThemeToggle />
 
-            {isAuthenticated ? (
-              <UserMenu onOpenSettings={() => setSettingsModalOpen(true)} onOpenApiKeys={() => setApiKeysModalOpen(true)} />
-            ) : (
-              <Button
-                onClick={() => setLoginModalOpen(true)}
-                className="text-sm md:text-base px-3 md:px-4 py-1.5 md:py-2"
-              >
-                Sign In
-              </Button>
-            )}
+            <UserMenu onOpenSettings={() => setSettingsModalOpen(true)} onOpenApiKeys={() => setApiKeysModalOpen(true)} />
           </div>
         </div>
       </header>


### PR DESCRIPTION
Drives the **79** open code-scanning alerts (78 CodeQL + 1 Scorecard) toward zero.

## Breakdown
| Bucket | Count | Action |
|---|---|---|
| Generated/vendored `wiki/site` (MkDocs output + lunr search lib) | 37 | CodeQL `paths-ignore` (new `.github/codeql/codeql-config.yml`) |
| Real fixes in `server/` + `src/` | 30 | code changes below |
| Confirmed false positives | 11 | dismissed via API w/ written justification |
| CSRF `cookieParser` FP | 1 | dismissed (global double-submit middleware) |
| Scorecard SAST `#85` | 1 | **not a FP** — 9/10 metric ("27/30 commits SAST-checked"); self-recomputes as CodeQL runs on more commits |

## Real fixes
- **Prototype pollution** (`audit.js`, `auth.js`): guard request-keyed maps (`redact()` meta; password-reset token map) against `__proto__`/`constructor`/`prototype`; getter uses `Object.hasOwn`.
- **Helmet hardened** (`index.js`): replace `contentSecurityPolicy: false` with a locked-down API policy (`default-src`/`frame-ancestors`/`base-uri`/`form-action` `'none'`). nginx owns the SPA's CSP and deliberately omits CSP on `/api`, so no duplication. ⚠️ `/api` JSON responses now carry `Content-Security-Policy: default-src 'none'` (inert for JSON) — worth a `curl -I .../api/health` sanity check post-deploy.
- **Log injection** (`deployment-logger.js`, `email.js`): strip CR/LF + C0/DEL control chars from untrusted values before logging.
- **user-controlled-bypass** (`progress-stream.js`): normalize `deploymentMode.type` against an allowlist (fallback `standard`, matching the prior switch default) — behavior preserved.
- **Dead code**: removed dead `dockerStatus` assignments + orphaned `execSync` import (`health.js`); confirmed-unused imports (`auth.js`, `index.js`, `environment-manager.js`, `network-manager.js`, `routes/auth-admin.js`); unreachable `!isAuthenticated` ternary branch (`App.tsx`).

## False positives dismissed (with justification)
- `insufficient-password-hash` ×2 — API keys are 256-bit `crypto.randomBytes` tokens HMAC-SHA256'd with an HKDF-derived server secret; bcrypt applies to low-entropy passwords (which DO use bcrypt cost 12 elsewhere).
- `user-controlled-bypass` ×5 — fail-closed presence/MFA/optional-auth guards; the security decision is made by the downstream crypto verifier.
- `http-to-file-access` ×4 — write paths are fixed module constants; request data only reaches file *contents*, never the path (no traversal).
- `missing-token-validation` ×1 — CSRF enforced by mandatory global double-submit middleware (`index.js`); CodeQL can't follow the custom guard from `cookieParser()`.

## Verification
- [x] `eslint server src --quiet` — clean
- [x] `tsc --noEmit` — clean (only pre-existing `baseUrl` deprecation)
- [x] full vitest — **906 pass** (one timeout flake under load re-confirmed passing in isolation)

## Note on timing
The 30 code-fixed + 37 wiki alerts close in the UI only after this merges and **CodeQL re-runs on `main`** — that's how code-scanning works. The 12 FPs are dismissed immediately. Expect the count to collapse 79 → ~1 (the Scorecard metric) after the post-merge CodeQL run.

## Rollback
`git revert b39285e` (single commit).

Epic HLCE-289 · Story HLCE-291