### PR TITLE
HLCE-291: make log-injection sanitizer CodeQL-recognized

### DIFF
--- a/server/deployment-logger.js
+++ b/server/deployment-logger.js
@@ -72,8 +72,11 @@ export class DeploymentLogger {
    * @private
    */
   static #sanitizeForLog(value) {
+    // Strip CR/LF first (this is what prevents forged/split log lines), then any
+    // other C0/DEL control chars. The explicit [\r\n] replace is the form CodeQL
+    // recognizes as a js/log-injection sanitizer.
     // eslint-disable-next-line no-control-regex
-    return String(value).replace(/[\x00-\x1f\x7f]/g, ' ');
+    return String(value).replace(/[\r\n]+/g, ' ').replace(/[\x00-\x1f\x7f]/g, ' ');
   }
 
   /**
@@ -83,36 +86,32 @@ export class DeploymentLogger {
   static #outputLog(logEntry, emoji = '') {
     const { level, component, message, timestamp, ...context } = logEntry;
 
-    // Create formatted message. message/component/context can carry untrusted
-    // values (CORS origins, request URLs, Docker error text), so neutralize
-    // CR/LF and other control chars before they reach the console to prevent
-    // forged log entries (CodeQL js/log-injection).
-    const formattedMessage = DeploymentLogger.#sanitizeForLog(`${emoji} [${component}] ${message}`);
-
-    // Create context string if context exists. JSON.stringify already escapes
-    // CR/LF and control chars inside string values to their \uXXXX/\n literals,
-    // so the only real newlines here are the pretty-print indentation — safe.
-    const contextStr = Object.keys(context).length > 0 ?
-      '\n' + JSON.stringify(context, null, 2) : '';
+    // message/component AND the context values are all request-derived (CORS
+    // origins, request URLs, Docker error text). Build the whole line and run it
+    // through the sanitizer so no untrusted CR/LF in either the message or the
+    // serialized context can forge or split a log entry (CodeQL js/log-injection).
+    // Context is serialized compactly because sanitizing strips newlines anyway.
+    const contextStr = Object.keys(context).length > 0 ? ' ' + JSON.stringify(context) : '';
+    const body = DeploymentLogger.#sanitizeForLog(`${emoji} [${component}] ${message}${contextStr}`);
 
     // Output based on log level
     switch (level.toLowerCase()) {
       case 'info':
-        console.log(`ℹ️  ${formattedMessage}${contextStr}`);
+        console.log(`ℹ️  ${body}`);
         break;
       case 'warn':
-        console.warn(`⚠️  ${formattedMessage}${contextStr}`);
+        console.warn(`⚠️  ${body}`);
         break;
       case 'error':
-        console.error(`❌ ${formattedMessage}${contextStr}`);
+        console.error(`❌ ${body}`);
         break;
       case 'debug':
         if (this.#getConfig().environment === 'development' || this.#getConfig().logLevel === 'debug') {
-          console.log(`🐛 ${formattedMessage}${contextStr}`);
+          console.log(`🐛 ${body}`);
         }
         break;
       default:
-        console.log(`📝 ${formattedMessage}${contextStr}`);
+        console.log(`📝 ${body}`);
     }
 
     return logEntry;

--- a/server/email.js
+++ b/server/email.js
@@ -4,8 +4,10 @@ import nodemailer from 'nodemailer';
 // console, so a tainted recipient/subject/body (e.g. a forged Host header that
 // reaches the reset URL) cannot forge or split log entries (CodeQL
 // js/log-injection).
+// Strip CR/LF first (the explicit [\r\n] form is what CodeQL recognizes as a
+// js/log-injection sanitizer) then any other C0/DEL control chars.
 // eslint-disable-next-line no-control-regex
-const stripLogControl = (v) => String(v).replace(/[\x00-\x1f\x7f]/g, ' ');
+const stripLogControl = (v) => String(v).replace(/[\r\n]+/g, ' ').replace(/[\x00-\x1f\x7f]/g, ' ');
 
 let transporter;
 


### PR DESCRIPTION
Follow-up to #354. The 6 `js/log-injection` alerts (deployment-logger ×5, email ×1) stayed open after #354 because the sanitizer used a hex char-class (`/[\x00-\x1f\x7f]/`) that CodeQL does not model as newline-removing — proven by email.js, which wraps each value directly yet still flagged.

## Fix
- Lead both sanitizers with an explicit `/[\r\n]+/g` replace (CodeQL's recognized log-injection sanitizer form), keeping the control-char strip as defense-in-depth.
- deployment-logger: sanitize the **full** line including the serialized `context` (that was a second, unsanitized sink input); context now serializes compactly since sanitizing strips newlines anyway.

## Verification
- [x] eslint clean, deployment-logger + email tests pass (9)
- [ ] CodeQL re-run on main clears alerts #109–113 + #184

## Rollback
`git revert c8f361a`

Epic HLCE-289 · Story HLCE-291