### PR TITLE
HLCE-290: patch npm-bundled undici (CVE-2026-12151) in backend image

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -6,11 +6,15 @@ FROM node:24-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7
 # Update Alpine packages to pick up latest security patches
 RUN apk upgrade --no-cache
 
-# Force-update npm and patch vulnerable transitive deps (minimatch, tar)
+# Force-update npm and patch vulnerable transitive deps (minimatch, tar, undici).
+# undici is bundled inside npm itself; npm@latest still ships an undici with
+# CVE-2026-12151 (HIGH, WebSocket-frame DoS), so pin it forward here. npm is a
+# build-time tool only — the runtime entrypoint is dumb-init/node — but Trivy
+# scans the image filesystem, so patch it to keep the scan clean (HLCE-290).
 RUN npm install -g npm@latest && \
-    npm install -g minimatch@latest tar@latest 2>/dev/null; \
+    npm install -g minimatch@latest tar@latest undici@latest 2>/dev/null; \
     cd /usr/local/lib/node_modules/npm && \
-    npm install minimatch@latest tar@latest --save 2>/dev/null; \
+    npm install minimatch@latest tar@latest undici@latest --save 2>/dev/null; \
     true
 
 # Set working directory


### PR DESCRIPTION
## What changed
Extend the existing npm-bundled-dep patch block in `Dockerfile.backend` (which already force-patches minimatch/tar) to also pin `undici@latest`.

## Why
Trivy — restored to report on `main` by #353 — flagged **CVE-2026-12151** (HIGH): a WebSocket-frame DoS in **undici 6.26.0** bundled inside `npm` in the `node:24-alpine` base image (`usr/local/lib/node_modules/npm/node_modules/undici`).

- The app's **runtime** undici is already **7.28.0** (patched), pulled via jsdom/dotenvx.
- `npm` is **build-time only** — the container entrypoint is `dumb-init → node`, never npm serving WebSocket traffic — so this is **not a runtime attack surface**.
- But Trivy scans the image filesystem, so we patch npm's bundled copy to clear the alert.

## Effect
- npm's bundled undici moves to a fixed version (≥6.27 / 7.x), clearing alert #191.

## Verification
- [ ] Backend image rebuilt on ce-prod, pushed, redeployed to demo/staging/dev
- [ ] Trivy re-scan on main shows 0 results for `trivy-homelabarr-backend` / alert #191 closed

## Rollback
`git revert` this commit (single Dockerfile line).