### PR TITLE
HLCE-290: fix undici patch — pack-and-replace npm's bundled copy

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -6,16 +6,19 @@ FROM node:24-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7
 # Update Alpine packages to pick up latest security patches
 RUN apk upgrade --no-cache
 
-# Force-update npm and patch vulnerable transitive deps (minimatch, tar, undici).
-# undici is bundled inside npm itself; npm@latest still ships an undici with
-# CVE-2026-12151 (HIGH, WebSocket-frame DoS), so pin it forward here. npm is a
-# build-time tool only — the runtime entrypoint is dumb-init/node — but Trivy
-# scans the image filesystem, so patch it to keep the scan clean (HLCE-290).
+# Force-update npm, then patch its bundled undici (CVE-2026-12151, HIGH —
+# WebSocket-frame DoS in undici 6.26.0, which npm@latest still ships at
+# /usr/local/lib/node_modules/npm/node_modules/undici). npm is a build-time tool
+# only — the runtime entrypoint is dumb-init/node, never npm — but Trivy scans
+# the whole image filesystem, so we swap in the fixed in-major release (HLCE-290).
+# `npm install` inside npm's own dir fails (its manifest references the
+# unpublished internal @npmcli/docs workspace dep), so pack-and-replace instead.
 RUN npm install -g npm@latest && \
-    npm install -g minimatch@latest tar@latest undici@latest 2>/dev/null; \
-    cd /usr/local/lib/node_modules/npm && \
-    npm install minimatch@latest tar@latest undici@latest --save 2>/dev/null; \
-    true
+    cd /tmp && npm pack undici@6.27.0 && \
+    tar -xzf undici-6.27.0.tgz && \
+    rm -rf /usr/local/lib/node_modules/npm/node_modules/undici && \
+    mv package /usr/local/lib/node_modules/npm/node_modules/undici && \
+    rm -f /tmp/undici-6.27.0.tgz
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## What changed
Replace the broken `npm install undici@latest --save` (inside npm's own dir) with `npm pack undici@6.27.0` + a filesystem swap of npm's bundled `undici/` directory.

## Why
The approach merged in #365 **silently failed**. Running `npm install` inside `/usr/local/lib/node_modules/npm` 404s because npm's manifest references the unpublished internal `@npmcli/docs` workspace dep. After rebuilding, npm's bundled undici was still **6.26.0** (verified). The pre-existing minimatch/tar `--save` patch was the same silent no-op (hidden by `2>/dev/null; true`).

## Fix
`npm pack undici@6.27.0` downloads the tarball; we extract and `mv` it over npm's bundled `undici/`. Verified in `node:24-alpine`: bundled undici → **6.27.0**, npm registry client still works. Pinned to the in-major fix (6.27.0) to avoid a major undici bump under npm.

## Verification
- [ ] Rebuilt backend image shows bundled undici 6.27.0
- [ ] Trivy re-scan on main: alert #191 closed

## Rollback
`git revert` this commit.