### PR TITLE
HLCE-295: smoke E2E reuses one session (fix 15-min rate-limit cascade)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ server/activity-data/
 # Playwright auth state
 playwright/.auth/
 tests/e2e/seeded/.seeded-mfa.json
+tests/e2e/.smoke-auth.json
 
 # Playwright MCP screenshot artifacts (transient)
 .playwright-mcp/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { SMOKE_STATE_FILE } from './tests/e2e/helpers';
 
 // Two lanes (HLCE-226):
 //   • `seeded` — the deterministic containerised target from docker-compose.e2e.yml
@@ -41,10 +42,18 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], baseURL: SEEDED_URL },
       dependencies: ['setup'],
     },
+    // Logs in once against the live smoke target and saves storageState, so the
+    // smoke specs reuse one session instead of one login per test (HLCE-295).
+    {
+      name: 'smoke-setup',
+      testMatch: /smoke\.setup\.ts$/,
+      use: { baseURL: SMOKE_URL },
+    },
     {
       name: 'smoke',
       testMatch: /(catalog|dark-mode|footer|icons|modals)\.spec\.ts$/,
-      use: { ...devices['Desktop Chrome'], baseURL: SMOKE_URL },
+      use: { ...devices['Desktop Chrome'], baseURL: SMOKE_URL, storageState: SMOKE_STATE_FILE },
+      dependencies: ['smoke-setup'],
     },
   ],
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,19 +1,26 @@
 import { expect, type Page } from '@playwright/test';
 
-// Log in through the inline Sign In screen and wait for the dashboard.
-//
-// We log in per test rather than reuse a saved session: the app logs you out on
-// reload (GET /api/auth/me returns the user flat, but AuthContext reads data.user),
-// so storageState / session-reuse lands back on the login wall. The login response
-// itself is correct, so a fresh UI login works. ce-dev is warm so this is fast; we
-// still retry the fill until the value sticks to survive any hydration race.
+// Persisted-session file for the live smoke lane (gitignored). The `smoke-setup`
+// project logs in once and writes it; the smoke specs reuse it via storageState
+// so the suite makes a single login instead of one per test. (HLCE-295.)
+export const SMOKE_STATE_FILE = 'tests/e2e/.smoke-auth.json';
+
+// Ensure we land on the authenticated dashboard. With a reused session
+// (storageState) the dashboard renders immediately and we skip the login form;
+// without one we log in through the inline Sign In screen. We race the login form
+// against the dashboard so the already-authenticated path stays fast (no waiting
+// out the full login-form timeout on every test).
 export async function login(page: Page): Promise<void> {
   await page.goto('/');
 
   const username = page.locator('#login-username');
   const password = page.locator('#login-password');
+  const dashboard = page.locator('text=/Connected|Browse Mode/').first();
 
-  if (await username.isVisible({ timeout: 20_000 }).catch(() => false)) {
+  // Whichever appears first: the login wall, or the already-authenticated dashboard.
+  await expect(username.or(dashboard).first()).toBeVisible({ timeout: 20_000 });
+
+  if (await username.isVisible()) {
     await expect(async () => {
       await username.fill('admin');
       await password.fill('admin');

--- a/tests/e2e/smoke.setup.ts
+++ b/tests/e2e/smoke.setup.ts
@@ -1,0 +1,12 @@
+import { test as setup } from '@playwright/test';
+import { login, SMOKE_STATE_FILE } from './helpers';
+
+// Authenticate ONCE against the live smoke target and persist the session, so the
+// cosmetic smoke specs reuse it instead of each logging in fresh. A live deploy
+// rate-limits logins (25 / 15 min / IP, server/ratelimit.js); 18 per-test logins
+// plus Playwright retries from a single CI-runner IP used to 429-cascade the suite
+// into the 15-minute timeout cap. One login keeps us well under. (HLCE-295.)
+setup('authenticate against the smoke target', async ({ page }) => {
+  await login(page);
+  await page.context().storageState({ path: SMOKE_STATE_FILE });
+});


### PR DESCRIPTION
## What changed
The live ce-dev smoke lane logged in **fresh per test** (18 logins). With Playwright `retries: 2` from a single runner IP, that crossed ce-dev's login limiter (**25 / 15 min / IP**, `server/ratelimit.js`) → `429` cascade → tests fail login → suite grinds into the **15-min timeout cap**.

The per-test login was a workaround for a reload-logout bug that's **already fixed** (`/auth/me` returns `{user}`, `AuthContext` reads `data.user`), so session reuse works again.

- **`smoke-setup` project** logs in once, saves `storageState`; the `smoke` project `dependencies` on it and reuses the session → **1 login instead of 18**.
- **`login()` is now session-aware**: races the login form against the dashboard via `locator.or()`, so the already-authenticated path is fast (no ~20s/test login-form wait).
- Removed the stale "logs you out on reload" comment; gitignored `.smoke-auth.json`.

## Verification
CI-faithful run (`CI=1 workers=1 retries=2`) against ce-dev:
```
19 passed (18.6s)
```
Down from the 15-minute cap. `tsc` + `eslint` clean on changed files.

ce-dev was healthy throughout — this was a self-inflicted test-design + rate-limit collision, not an env problem.

Closes HLCE-295.