### PR TITLE
HLCE-296: bump backend base + weekly no-cache rebuild (fix stale docker-cli CVE)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -9,6 +9,11 @@ on:
   push:
     branches: [main, dev]
     tags: ['v*']
+  # Weekly no-cache rebuild so security-sensitive layers (the Alpine-edge
+  # docker-cli binary and the base image) can't silently freeze in the gha
+  # build cache and keep shipping a stale, CVE-flagged binary. (HLCE-296.)
+  schedule:
+    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       push_images:
@@ -117,6 +122,9 @@ jobs:
         labels: ${{ steps.meta-frontend.outputs.labels }}
         cache-from: type=gha
         cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
+        # The weekly scheduled run builds from scratch so the Alpine-edge
+        # docker-cli and base layers refresh instead of freezing. (HLCE-296.)
+        no-cache: ${{ github.event_name == 'schedule' }}
         provenance: ${{ github.event_name != 'pull_request' }}
         sbom: ${{ github.event_name != 'pull_request' }}
         build-args: |
@@ -135,6 +143,9 @@ jobs:
         labels: ${{ steps.meta-backend.outputs.labels }}
         cache-from: type=gha
         cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
+        # The weekly scheduled run builds from scratch so the Alpine-edge
+        # docker-cli and base layers refresh instead of freezing. (HLCE-296.)
+        no-cache: ${{ github.event_name == 'schedule' }}
         provenance: ${{ github.event_name != 'pull_request' }}
         sbom: ${{ github.event_name != 'pull_request' }}
         build-args: |

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,7 +1,7 @@
 # HomelabARR Backend Docker Image
 # Optimized Node.js backend with CLI Bridge integration
 
-FROM node:24-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
+FROM node:24-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436
 
 # Update Alpine packages to pick up latest security patches
 RUN apk upgrade --no-cache


### PR DESCRIPTION
## What changed
Docker Scout graded `smashingtags/homelabarr-backend:latest` a **C** — HIGH **CVE-2026-34040** (`docker/docker` 28.5.2, fix 29.3.1) in the docker-cli Go binary, plus an outdated base image.

**Root cause:** Alpine edge already ships `docker-cli` **29.6.0**, but `docker-build-push.yml` caches the `RUN apk add docker-cli` layer via `cache-from/to: gha` with no cache-bust → the security-sensitive binary froze at 28.5.2.

- **Bump `node:24-alpine3.23` base digest** → `sha256:595398b0…`. Clears the outdated-base policy, and cascades cache invalidation through the docker-cli layer so it re-resolves to 29.6.0 on the next build.
- **Weekly scheduled `no-cache` build** (Mon 06:00 UTC) so edge-sourced layers refresh on their own — the actual root-cause fix so this can't silently recur.

## Verification plan
Post-merge push-build republishes backend to GHCR + Docker Hub, then Scout re-scan of the new `:latest` should show **CVE-2026-34040 resolved** and the **outdated-base policy compliant** (C→B).

**Upstream-pending:** CVE-2026-42504 (Go stdlib 1.26.3→1.26.4) stays flagged until Alpine edge ships go 1.26.4 (edge go is still 1.26.3). Tracked, not blocking.

Closes HLCE-296.