### PR TITLE
HLCE-300: ignore typescript >=6.1.0 in dependabot dev-tools group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,11 @@ updates:
     allow:
       - dependency-type: "direct"
       - dependency-type: "indirect"
+    ignore:
+      # typescript-eslint@8.63.0 peer-requires typescript ">=4.8.4 <6.1.0";
+      # a TS7 bump ERESOLVEs the whole dev-tools group (broke HLCE PR #385).
+      - dependency-name: "typescript"
+        versions: [">=6.1.0"]
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Summary
- typescript-eslint@8.63.0 peer-requires typescript ">=4.8.4 <6.1.0"; dependabot's grouped dev-tools bump pulled in typescript 7.0.2 and ERESOLVE-broke every npm-ci-based check (lint/type-check/vitest, license audit, CVE scan, SBOM, bundle secret scan) — see PR #385.
- Adds an `ignore` rule for `typescript` versions `>=6.1.0` so future dev-tools group PRs skip the incompatible major instead of failing whole-group.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [ ] Next scheduled dev-tools dependabot run no longer proposes a typescript bump past 6.0.x

Ref: HLCE-300