### PR TITLE
HLCE-302: resolve 4 open security alerts

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -13,12 +13,19 @@ RUN apk upgrade --no-cache
 # the whole image filesystem, so we swap in the fixed in-major release (HLCE-290).
 # `npm install` inside npm's own dir fails (its manifest references the
 # unpublished internal @npmcli/docs workspace dep), so pack-and-replace instead.
+# Same pattern patches tar <=7.5.20 (GHSA-r292-9mhp-454m, MEDIUM — uncontrolled
+# recursion in mapHas/filesFilter) bundled inside npm@latest (HLCE-302).
 RUN npm install -g npm@latest && \
     cd /tmp && npm pack undici@6.27.0 && \
     tar -xzf undici-6.27.0.tgz && \
     rm -rf /usr/local/lib/node_modules/npm/node_modules/undici && \
     mv package /usr/local/lib/node_modules/npm/node_modules/undici && \
-    rm -f /tmp/undici-6.27.0.tgz
+    rm -f /tmp/undici-6.27.0.tgz && \
+    npm pack tar@7.5.21 && \
+    tar -xzf tar-7.5.21.tgz && \
+    rm -rf /usr/local/lib/node_modules/npm/node_modules/tar && \
+    mv package /usr/local/lib/node_modules/npm/node_modules/tar && \
+    rm -f /tmp/tar-7.5.21.tgz
 
 # Set working directory
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1649,13 +1649,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   },
   "overrides": {
     "path-to-regexp": "^8.2.0",
-    "qs": "6.14.2"
+    "qs": "6.14.2",
+    "@hono/node-server": "^2.0.5"
   }
 }


### PR DESCRIPTION
## What
- Override `@hono/node-server` to `^2.0.5` in package.json — resolves Dependabot #104
- Bump `shadcn` 4.11.0 → 4.16.0 (matches existing `^4.16.0` specifier that was unsatisfied)
- `Dockerfile.backend`: pack-and-swap `tar@7.5.21` into npm's bundled tar to clear GHSA-r292-9mhp-454m (Trivy #209)

## AC checklist
- [x] AC1: Dependabot #104 — override forces @hono/node-server to 2.0.12 (`npm ls` verified)
- [x] AC2/AC3: source-side protobufjs + brace-expansion fixes already shipped in PRs #399, #412; clear on image rebuild
- [x] AC4: tar patched via same pack-and-swap pattern HLCE-290 used for undici
- [ ] AC5: Scorecard #207 needs manual dismissal in GitHub UI (Branch-Protection heuristic — known noise)
- [ ] AC6: requires image rebuild on ce-prod after merge

## Verified locally
- `npm ls @hono/node-server` → 2.0.12 ✅
- `npm run lint` → 0 errors, 16 pre-existing warnings ✅
- `npx tsc --noEmit` (both tsconfigs) → 0 errors ✅
- `npm run test:run` → 906/906 pass ✅
- `npm run test:coverage` → 83.06/82.22/81.61/74.9 (gate 82/81/80/74 holds) ✅

## Rollback
- `git revert 1dc89cf` — drops both the override and the Dockerfile.tar swap in one revert
- Override removal: `npm uninstall <none>` — re-edit package.json to remove the @hono/node-server override key