### PR TITLE
HLCE-305: consolidate four lock bumps and pin node to major 24

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@
 # Force LF for Docker and config files
 Dockerfile* text eol=lf
 *.conf text eol=lf
+
+# npm can rewrite the lock with CRLF, which turns a 4-package bump into a
+# 28,000-line whole-file diff and hides the real change.
+package-lock.json text eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,9 @@ updates:
       include: "scope"
     allow:
       - dependency-type: "direct"
+    ignore:
+      # Node 25 is the Current line and never becomes LTS; 24 is Active LTS and
+      # is what every CI lane pins (node-version: 24). Taking a major here would
+      # split the runtime from CI. Revisit when 26 goes LTS (PR #426).
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1294,22 +1294,22 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -1326,15 +1326,15 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
     },
     "node_modules/@fontsource-variable/geist": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.9.tgz",
-      "integrity": "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.3.0.tgz",
+      "integrity": "sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -4720,9 +4720,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -9201,12 +9201,16 @@
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {


### PR DESCRIPTION
Closes the last four conflicting Dependabot PRs in one commit and stops the node-major PR from regenerating daily.

## What changed
- `package-lock.json` — media-typer 1.1.1 (#420), @floating-ui/dom 1.8.0 (#421), @fontsource-variable/geist 5.3.0 (#422), @ungap/structured-clone 1.3.3 (#423), plus @floating-ui/core + utils pulled along transitively
- `.github/dependabot.yml` — ignore `node` semver-major in the docker ecosystem
- `.gitattributes` — pin `package-lock.json` to LF

## Why one commit instead of four merges
After #436 (dev-tools, 32 updates) landed, all four went CONFLICTING on the lock. Merging them individually means four rebase-and-wait cycles where each merge re-conflicts the remaining three.

## Why ignore node majors
PR #426 proposed node 24-alpine → 25-alpine on both Dockerfiles. Node 25 is an odd-numbered **Current** release that never becomes LTS; Node 24 is Active LTS and is what `unit-tests.yml` and `e2e-tests.yml` both pin (`node-version: 24`). Merging it would split the runtime from CI. Revisit when Node 26 goes LTS.

## The CRLF trap
`npm update` rewrote the lock with CRLF endings, rendering a 46-line change as **14,054 insertions / 14,050 deletions**. Normalised to LF; the `.gitattributes` rule keeps the next bump reviewable.

## Verification
```
npm ci                                        clean (956 packages)
npx tsc --project tsconfig.app.json --noEmit  clean  (the command CI runs)
npm run lint                                  0 errors, 16 pre-existing warnings
npm test                                      906/906 passed, 61 files
```

Expected red checks: `E2E (seeded target)` and `ATT&CK external (class A1)` — both fail on every branch at baseline, tracked in HLCE-306.

Ticket: https://mjashley.atlassian.net/browse/HLCE-305