### PR TITLE
HLCE-304: remove npm from the backend image instead of patching its deps

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -6,27 +6,6 @@ FROM node:24-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb484
 # Update Alpine packages to pick up latest security patches
 RUN apk upgrade --no-cache
 
-# Force-update npm, then patch its bundled undici (CVE-2026-12151, HIGH —
-# WebSocket-frame DoS in undici 6.26.0, which npm@latest still ships at
-# /usr/local/lib/node_modules/npm/node_modules/undici). npm is a build-time tool
-# only — the runtime entrypoint is dumb-init/node, never npm — but Trivy scans
-# the whole image filesystem, so we swap in the fixed in-major release (HLCE-290).
-# `npm install` inside npm's own dir fails (its manifest references the
-# unpublished internal @npmcli/docs workspace dep), so pack-and-replace instead.
-# Same pattern patches tar <=7.5.20 (GHSA-r292-9mhp-454m, MEDIUM — uncontrolled
-# recursion in mapHas/filesFilter) bundled inside npm@latest (HLCE-302).
-RUN npm install -g npm@latest && \
-    cd /tmp && npm pack undici@6.27.0 && \
-    tar -xzf undici-6.27.0.tgz && \
-    rm -rf /usr/local/lib/node_modules/npm/node_modules/undici && \
-    mv package /usr/local/lib/node_modules/npm/node_modules/undici && \
-    rm -f /tmp/undici-6.27.0.tgz && \
-    npm pack tar@7.5.21 && \
-    tar -xzf tar-7.5.21.tgz && \
-    rm -rf /usr/local/lib/node_modules/npm/node_modules/tar && \
-    mv package /usr/local/lib/node_modules/npm/node_modules/tar && \
-    rm -f /tmp/tar-7.5.21.tgz
-
 # Set working directory
 WORKDIR /app
 
@@ -49,10 +28,23 @@ RUN addgroup -g 1001 homelabarr && \
     adduser -u 1001 -G homelabarr -s /bin/bash -D homelabarr
 
 # Copy package files and install dependencies (with native build tools for better-sqlite3-multiple-ciphers)
+#
+# npm is deleted in this same layer once it has done its job. It is a build-time
+# tool only — the entrypoint is dumb-init and the command is `bash
+# server/start.sh`, neither of which touches npm or npx. But Trivy scans the
+# whole image filesystem, and npm vendors its own dependency tree, which is
+# where every image CVE on this backend has come from: undici (HLCE-290), tar
+# (HLCE-302), then undici again plus ip-address and brace-expansion (HLCE-304).
+# Hand-patching that tree meant re-patching it every few weeks; removing npm
+# retires the entire alert class instead.
 COPY package*.json ./
 RUN apk add --no-cache --virtual .build python3 make g++ && \
     npm ci --only=production --no-audit --loglevel=error --no-fund && \
-    apk del .build
+    apk del .build && \
+    rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm \
+           /usr/local/bin/npx \
+           /root/.npm
 
 # Copy server files and configurations
 COPY server/ ./server/


### PR DESCRIPTION
Retires the recurring Trivy alert class on the backend image by deleting npm after it has done its job, instead of hand-patching its vendored dependencies for a third time.

## The problem
All 8 open Trivy code-scanning alerts live in npm's own vendored tree inside the image — not in application dependencies:

| Package | Alerts |
|---|---|
| `npm/node_modules/undici` | CVE-2026-16729, CVE-2026-16728, CVE-2026-15157 |
| `npm/node_modules/ip-address` | CVE-2026-69192 (HIGH), CVE-2026-69198, CVE-2026-54272 |
| `npm/node_modules/brace-expansion` | CVE-2026-69152 (HIGH), CVE-2026-14257 |

`Dockerfile.backend` carried a pack-and-swap block from HLCE-290 (undici) extended in HLCE-302 (tar) that replaced those packages by hand. It has now gone stale twice — a recurring tax that never converges.

## The fix
npm is build-time only. `ENTRYPOINT` is `dumb-init`, `CMD` is `bash server/start.sh`, and `server/start.sh` contains zero npm/npx references — the Dockerfile's own comment already said so. Deleting npm in the same layer as `npm ci` removes the entire alert class permanently.

It also removes the unpinned `npm install -g npm@latest` that Scorecard alert #195 ("npmCommand not pinned by hash") flags on this same file.

`corepack` is deliberately left alone — it ships no vendored `node_modules` (784K of `dist` only), so it carries no comparable CVE surface.

## Verification (local, arm64)
```
npm / npx in built image        ABSENT (both)
npm / npx in running container  ABSENT (both)
image size                      921MB -> 890MB
compose up (e2e stack)          backend reaches Healthy
/health in-container            200
/health via frontend proxy      200
seeded Playwright suite         18/18 passed
```

The seeded E2E suite exercises login, MFA, TOTP, backup codes, deploy-through-the-stream, container start/stop/restart/logs/remove, port-conflict failure and permissions — all green against the npm-removed image.

**Still outstanding:** AC5 (Trivy reports 0 npm-vendored CVEs) can only be confirmed by the scan on main after merge. ce-prod (192.168.1.231) and staging (.232) were unreachable during this work, so the x86_64 build/push/deploy still needs doing when they are back.

Expected red checks: `E2E (seeded target)` and `ATT&CK external (class A1)` — both fail on every branch at baseline, tracked in HLCE-306.

Ticket: https://mjashley.atlassian.net/browse/HLCE-304