### PR TITLE
HLCE-306: guard the native build and give the E2E lane real diagnostics

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,8 +3,11 @@ name: E2E Tests
 on:
   pull_request:
     branches: [dev, staging, main]
+  # main included so a broken lane surfaces without waiting for someone to open
+  # a PR. HLCE-306 went unnoticed for two weeks because main had no E2E signal
+  # at all and every PR was red for the same reason, so nobody could tell.
   push:
-    branches: [dev]
+    branches: [dev, main]
 
 permissions:
   contents: read
@@ -32,6 +35,26 @@ jobs:
 
       - name: Build + start the seeded target
         run: docker compose -p hlce-e2e -f docker-compose.e2e.yml up -d --build
+
+      # `up -d --build` aborts with a bare "container is unhealthy" and prints
+      # nothing about why. The diagnostics below used to live only in the
+      # wait-for-health step, which never ran when the failure happened here —
+      # so HLCE-306 showed two weeks of red with zero evidence in the logs.
+      - name: Diagnose a failed bring-up
+        if: ${{ failure() }}
+        run: |
+          echo "::group::compose ps"
+          docker compose -p hlce-e2e -f docker-compose.e2e.yml ps -a || true
+          echo "::endgroup::"
+          for svc in backend socket-proxy frontend; do
+            echo "::group::$svc logs"
+            docker compose -p hlce-e2e -f docker-compose.e2e.yml logs --tail=120 "$svc" || true
+            echo "::endgroup::"
+          done
+          echo "::group::backend healthcheck probes"
+          docker inspect hlce-e2e-backend \
+            --format '{{if .State.Health}}{{range .State.Health.Log}}exit={{.ExitCode}} {{.Output}}{{end}}{{end}}' || true
+          echo "::endgroup::"
 
       - name: Wait for the target to be healthy
         run: |

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -37,9 +37,19 @@ RUN addgroup -g 1001 homelabarr && \
 # (HLCE-302), then undici again plus ip-address and brace-expansion (HLCE-304).
 # Hand-patching that tree meant re-patching it every few weeks; removing npm
 # retires the entire alert class instead.
+#
+# The node -e line is a build-time assertion, not a formality. `npm install -g
+# npm@latest` used to run above this; when npm@latest floated 11.16.0 -> 12.0.2,
+# npm 12's new allowScripts policy silently blocked every install script, so
+# better-sqlite3-multiple-ciphers never compiled its native binding. The image
+# still built and pushed clean — it only died at runtime in server/db.js, then
+# restart-looped forever without ever binding :8092. That cost two weeks of a
+# red E2E lane (HLCE-306). Loading the module here turns that class of silent
+# breakage into a loud build failure.
 COPY package*.json ./
 RUN apk add --no-cache --virtual .build python3 make g++ && \
-    npm ci --only=production --no-audit --loglevel=error --no-fund && \
+    npm ci --omit=dev --no-audit --loglevel=error --no-fund && \
+    node -e "const D=require('better-sqlite3-multiple-ciphers'); new D(':memory:').close()" && \
     apk del .build && \
     rm -rf /usr/local/lib/node_modules/npm \
            /usr/local/bin/npm \


### PR DESCRIPTION
## Root cause

`E2E (seeded target)` failed on **every** branch for two weeks. It never reached Playwright — it died at `dependency failed to start: container hlce-e2e-backend is unhealthy`.

`Dockerfile.backend` ran `npm install -g npm@latest`. That floated **11.16.0 → 12.0.2**, and npm 12 blocks install scripts by default under its new `allowScripts` policy:

```
npm warn install-scripts 5 packages had install scripts blocked because they are not covered by allowScripts:
  better-sqlite3-multiple-ciphers@12.11.1 (install: prebuild-install || node-gyp rebuild --release)
  better-sqlite3@12.11.1, cpu-features@0.0.10, protobufjs@7.6.5, ssh2@1.17.0
```

So `better_sqlite3.node` was never compiled. The image **built and pushed clean**, then died at runtime in `server/db.js` with `Could not locate the bindings file`, restart-looped forever, and never bound `:8092` — surfacing only as compose's opaque "unhealthy".

Isolated experimentally against the real lock:

| npm | flags | `better_sqlite3.node` built |
|---|---|---|
| 11.16.0 | `--only=production` | **1** ✅ |
| 12.0.2 | `--only=production` | 0 ❌ |
| 12.0.2 | `--omit=dev` | 0 ❌ |
| 12.0.2 | `--omit=dev --ignore-scripts=false` | 0 ❌ |

Nothing in the repo changed. An unpinned floating dependency did.

**This was not just a CI problem** — any fresh build of `Dockerfile.backend` from main produced a backend that could not open its database. Rebuilding prod would have crash-looped it.

## What this PR adds

HLCE-304 already removed the npm upgrade, which fixes the bug (the digest-pinned base image supplies npm 11.16.0). This adds the guardrails so it cannot recur silently:

- **Build-time assertion** that the native module actually loads. Verified both directions — the normal build passes, and reintroducing `npm install -g npm@latest` now **fails the build** at that line rather than shipping an image that crash-loops.
- `--only=production` → `--omit=dev` (npm warns on the old alias; identical behaviour on npm 11).
- **Failure diagnostics** in the E2E lane: `compose ps`, per-service logs, and the backend's healthcheck probe output. The old diagnostics lived in the *wait-for-health* step, which never ran because the failure happened in the earlier `up -d --build` step — two weeks of red with zero evidence in the logs.
- **Run on push to main**, so main has E2E signal at all. It previously ran only on PRs and pushes to `dev`, which is why this went unnoticed.

## Verification
```
docker build (normal)                    PASS
docker build + npm@latest reintroduced   FAILS at the assertion (regression proven)
compose up                               backend -> Healthy
/api/health                              200
seeded Playwright suite                  18/18 passed
```

Also confirmed green in real CI on amd64: `E2E (seeded target)` **passed** on #438, the first green run in two weeks.

Ticket: https://mjashley.atlassian.net/browse/HLCE-306