### PR TITLE
HLCE-308: drop the unused better-sqlite3 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@radix-ui/react-tabs": "^1.1.21",
         "@radix-ui/react-tooltip": "^1.2.16",
         "bcryptjs": "^3.0.2",
-        "better-sqlite3": "^12.11.1",
         "better-sqlite3-multiple-ciphers": "^12.10.0",
         "chart.js": "^4.4.1",
         "class-variance-authority": "^0.7.1",
@@ -5233,20 +5232,6 @@
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
-      }
-    },
-    "node_modules/better-sqlite3": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/better-sqlite3-multiple-ciphers": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@radix-ui/react-tabs": "^1.1.21",
     "@radix-ui/react-tooltip": "^1.2.16",
     "bcryptjs": "^3.0.2",
-    "better-sqlite3": "^12.11.1",
     "better-sqlite3-multiple-ciphers": "^12.10.0",
     "chart.js": "^4.4.1",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
Supersedes #452.

## Why
`package.json` declared `better-sqlite3` as a direct production dependency, but **nothing imports it**. The only DB driver in use is the SQLCipher fork `better-sqlite3-multiple-ciphers`, imported once in `server/db.js`. Every other occurrence of the bare name is prose in CHANGELOG / wiki / `docs/audit/*`.

Not transitive either — `better-sqlite3-multiple-ciphers` depends only on `bindings` and `prebuild-install`, and the lock recorded `better-sqlite3` as required by `<root>` alone.

It is a native addon, so keeping it meant compiling it under the `.build` toolchain on every image build and shipping the `.node` into the runtime image for nothing — plus recurring Dependabot PRs. #452 proposed bumping it 12.11.1 → **13.0.3**, a major on a package we do not use. Deleting it is the correct answer.

## Verification
```
npm run lint                                  0 errors
npx tsc --project tsconfig.app.json --noEmit  exit 0
npm test                                      61 files / 906 tests passed
docker build -f Dockerfile.backend            PASS (HLCE-306 native assertion still holds)
image size                                    890MB -> 859MB
seeded Playwright suite                       18/18 passed
```

Native modules remaining in the image — `better-sqlite3` gone, the driver we actually use intact:
```
/app/node_modules/better-sqlite3-multiple-ciphers/build/Release/better_sqlite3.node
/app/node_modules/cpu-features/... , /app/node_modules/ssh2/...
```

Note: the `.gitattributes` LF pin from HLCE-305 did its job here — npm again wrote the lock as CRLF, and git normalised it, so this reads as a 16-line deletion instead of a 28,000-line whole-file diff.

Expected red check: `ATT&CK external (class A1)` (known baseline).

Ticket: https://mjashley.atlassian.net/browse/HLCE-308