### PR TITLE
HLCE-313: alert externally when the demo or dev goes down

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,117 @@
+name: Uptime
+
+# Runs on GitHub's infrastructure on purpose. The Prometheus stack on ce-prod
+# cannot report that ce-prod is down, and any checker living in the homelab dies
+# with the homelab — which is why the 2026-07-26 outage ran for sixteen days
+# before anyone noticed (HLCE-313). This check is independent of both the
+# homelab and the VPS.
+#
+# Silent when everything is healthy. It only speaks up when something is wrong.
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'Override targets (space-separated URLs) — used to prove the alert path works'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Probe public surfaces
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check targets
+        id: check
+        env:
+          OVERRIDE: ${{ inputs.targets }}
+        run: |
+          set -uo pipefail
+
+          # url|expected-substring ("" = only require HTTP 200)
+          DEFAULT_TARGETS=(
+            "https://demo.homelabarr.com/|"
+            "https://demo.homelabarr.com/api/health|\"ok\":true"
+            "https://ce-dev.homelabarr.com/|"
+            "https://ce-dev.homelabarr.com/api/health|\"ok\":true"
+          )
+
+          if [ -n "${OVERRIDE:-}" ]; then
+            TARGETS=(); for u in $OVERRIDE; do TARGETS+=("$u|"); done
+            echo "Using override targets"
+          else
+            TARGETS=("${DEFAULT_TARGETS[@]}")
+          fi
+
+          FAILURES=""
+          for entry in "${TARGETS[@]}"; do
+            url="${entry%%|*}"
+            expect="${entry#*|}"
+
+            # Retry before declaring an outage — a single dropped packet is not
+            # an incident, and a false alert teaches you to ignore alerts.
+            ok=false; status=""; detail=""
+            for attempt in 1 2 3; do
+              body_file="$(mktemp)"
+              # curl already emits 000 via -w when it cannot connect; a `|| echo 000`
+              # here would concatenate and report a nonsense "HTTP 000000".
+              status=$(curl -sS -m 20 -o "$body_file" -w '%{http_code}' "$url" 2>/dev/null || true)
+              [ -z "$status" ] && status="000"
+              body=$(head -c 500 "$body_file" 2>/dev/null); rm -f "$body_file"
+
+              if [ "$status" = "200" ]; then
+                if [ -z "$expect" ] || printf '%s' "$body" | grep -qF -- "$expect"; then
+                  ok=true; break
+                fi
+                detail="200 but response did not contain: $expect"
+              else
+                detail="HTTP $status"
+              fi
+              [ "$attempt" -lt 3 ] && sleep 10
+            done
+
+            if [ "$ok" = true ]; then
+              echo "OK    $url"
+            else
+              echo "DOWN  $url — $detail"
+              FAILURES="${FAILURES}- \`${url}\` — ${detail}\n"
+            fi
+          done
+
+          if [ -n "$FAILURES" ]; then
+            {
+              echo "failures<<EOF"
+              printf '%b' "$FAILURES"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "All targets healthy."
+
+      - name: Notify Discord
+        if: ${{ failure() && steps.check.outputs.failures != '' }}
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_HOMELABARR }}
+          FAILURES: ${{ steps.check.outputs.failures }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "DISCORD_WEBHOOK_HOMELABARR not set; skipping notification"
+            exit 0
+          fi
+          DESC=$(printf '%s\n\n[View run](%s)' "$FAILURES" "$RUN_URL")
+          # jq builds the JSON so the failure text is escaped correctly — it
+          # contains backticks, newlines and URLs.
+          payload=$(jq -n \
+            --arg desc "$DESC" \
+            --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{embeds:[{title:"HomelabARR is unreachable",description:$desc,color:15158332,timestamp:$ts,footer:{text:"uptime check - github actions"}}]}')
+          curl -sS -m 20 -X POST -H 'Content-Type: application/json' -d "$payload" "$WEBHOOK" >/dev/null \
+            && echo "Discord notified." || echo "Discord notification failed."


### PR DESCRIPTION
Closes the gap that let a public outage run for **sixteen days**.

## Why it has to be external
ce-prod runs Prometheus, Grafana, Loki and node-exporter — but there is **no Alertmanager and not one alert rule**. It collects metrics and tells nobody. It also runs *on* ce-prod, so it structurally cannot report that ce-prod is down. Any checker living in the homelab dies with the homelab.

This runs on GitHub's infrastructure: independent of both the homelab and the VPS, free on this public repo, and it reuses the existing `DISCORD_WEBHOOK_HOMELABARR` secret. No new service, no new account, no cost.

## Design decisions worth noting
- **`/api/health` must contain `"ok":true`, not merely return 200.** A 200 from a proxy sitting in front of a dead backend is *exactly* the failure mode we just had — ce-demo served 200 while its backend crash-looped.
- **Retries 3× before alerting.** One dropped packet is not an incident, and false alerts train you to ignore alerts.
- **Silent when healthy.** No routine noise, so a message means something.
- **Exits non-zero on failure**, so it is visible in the Actions tab even if Discord is missed.
- **`workflow_dispatch` accepts a targets override**, so the alert path can be proven against a deliberately bad URL rather than assumed to work.

## Verified locally
```
real targets      → 4/4 OK, exit 0, silent
dead host         → DOWN, HTTP 000, exit 1
content mismatch  → DOWN "200 but response did not contain", exit 1
YAML              → parses
jq payload        → valid JSON with backticks, quotes and newlines escaped
```
Also fixed a bug found in testing: `|| echo "000"` concatenated with curl's own `-w` output and reported `HTTP 000000`. A real alert showing a nonsense status undermines trust in every other alert.

I will prove the Discord path end to end on real CI after merge (AC6).

Expected red check: `ATT&CK external (class A1)` (known baseline).

Ticket: https://mjashley.atlassian.net/browse/HLCE-313