### PR TITLE
HLCE-313: surface why a Discord notification failed

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -113,5 +113,16 @@ jobs:
             --arg desc "$DESC" \
             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             '{embeds:[{title:"HomelabARR is unreachable",description:$desc,color:15158332,timestamp:$ts,footer:{text:"uptime check - github actions"}}]}')
-          curl -sS -m 20 -X POST -H 'Content-Type: application/json' -d "$payload" "$WEBHOOK" >/dev/null \
-            && echo "Discord notified." || echo "Discord notification failed."
+          # Report what Discord actually said. Swallowing this is how you ship
+          # an alerting system that looks fine and never pages anyone.
+          resp=$(mktemp)
+          code=$(curl -sS -m 20 -o "$resp" -w '%{http_code}' \
+            -X POST -H 'Content-Type: application/json' -d "$payload" "$WEBHOOK" || true)
+          [ -z "$code" ] && code="000"
+          if [ "$code" = "204" ] || [ "$code" = "200" ]; then
+            echo "Discord notified (HTTP $code)."
+          else
+            echo "Discord notification FAILED with HTTP $code"
+            echo "response: $(head -c 300 "$resp")"
+          fi
+          rm -f "$resp"


### PR DESCRIPTION
Follow-up to #459, found while proving AC6 end to end.

The probe worked — a deliberately bad target was detected (`DOWN … HTTP 000`) and the job failed as designed. But the Discord step reported only:

```
Discord notification failed.
```

with no cause, because curl's output went to `/dev/null`. An alerting system whose alert path fails quietly is worse than not having one: it looks healthy while paging nobody.

This logs Discord's HTTP status and response body so the next test says what is actually wrong. Then I can fix the real cause and re-prove AC6.

Ticket: https://mjashley.atlassian.net/browse/HLCE-313