### PR TITLE
HLCE-313: strip whitespace from the webhook secret before use

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -102,10 +102,18 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -uo pipefail
-          if [ -z "${WEBHOOK:-}" ]; then
+          # Strip whitespace. A secret pasted with a trailing newline yields a
+          # URL curl cannot parse, which surfaces as HTTP 000 — indistinguishable
+          # from the network being down, and it silently disables alerting.
+          WEBHOOK="$(printf '%s' "${WEBHOOK:-}" | tr -d '[:space:]')"
+          if [ -z "$WEBHOOK" ]; then
             echo "DISCORD_WEBHOOK_HOMELABARR not set; skipping notification"
             exit 0
           fi
+          case "$WEBHOOK" in
+            https://discord.com/api/webhooks/*|https://discordapp.com/api/webhooks/*) ;;
+            *) echo "WARNING: webhook secret is not a discord webhook URL (length ${#WEBHOOK}); attempting anyway" ;;
+          esac
           DESC=$(printf '%s\n\n[View run](%s)' "$FAILURES" "$RUN_URL")
           # jq builds the JSON so the failure text is escaped correctly — it
           # contains backticks, newlines and URLs.


### PR DESCRIPTION
Third and final follow-up on proving the alert path (AC6).

Test result after adding diagnostics: `Discord notification FAILED with HTTP 000` with an empty response body. `000` means curl never connected — not a rejection from Discord. The secret is non-empty (the step did not take the "not set" branch), so the URL itself is the problem.

The classic cause is a secret pasted with a trailing newline. The URL then fails to parse, curl reports `000`, and that is **indistinguishable from the network being down** — so alerting is silently disabled while looking configured.

This strips whitespace before use and warns, without printing the value, if the secret does not look like a Discord webhook URL. If it still fails after this, the log will now say the shape is wrong rather than blaming the network.

Ticket: https://mjashley.atlassian.net/browse/HLCE-313