### PR TITLE
HLCE-313: fall back across webhooks so one dead URL cannot mute alerting

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -97,23 +97,13 @@ jobs:
       - name: Notify Discord
         if: ${{ failure() && steps.check.outputs.failures != '' }}
         env:
-          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_HOMELABARR }}
+          WEBHOOK_1: ${{ secrets.DISCORD_WEBHOOK_HOMELABARR }}
+          WEBHOOK_2: ${{ secrets.DISCORD_CICD_WEBHOOK }}
+          WEBHOOK_3: ${{ secrets.DISCORD_RLS }}
           FAILURES: ${{ steps.check.outputs.failures }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -uo pipefail
-          # Strip whitespace. A secret pasted with a trailing newline yields a
-          # URL curl cannot parse, which surfaces as HTTP 000 — indistinguishable
-          # from the network being down, and it silently disables alerting.
-          WEBHOOK="$(printf '%s' "${WEBHOOK:-}" | tr -d '[:space:]')"
-          if [ -z "$WEBHOOK" ]; then
-            echo "DISCORD_WEBHOOK_HOMELABARR not set; skipping notification"
-            exit 0
-          fi
-          case "$WEBHOOK" in
-            https://discord.com/api/webhooks/*|https://discordapp.com/api/webhooks/*) ;;
-            *) echo "WARNING: webhook secret is not a discord webhook URL (length ${#WEBHOOK}); attempting anyway" ;;
-          esac
           DESC=$(printf '%s\n\n[View run](%s)' "$FAILURES" "$RUN_URL")
           # jq builds the JSON so the failure text is escaped correctly — it
           # contains backticks, newlines and URLs.
@@ -121,16 +111,28 @@ jobs:
             --arg desc "$DESC" \
             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             '{embeds:[{title:"HomelabARR is unreachable",description:$desc,color:15158332,timestamp:$ts,footer:{text:"uptime check - github actions"}}]}')
-          # Report what Discord actually said. Swallowing this is how you ship
-          # an alerting system that looks fine and never pages anyone.
-          resp=$(mktemp)
-          code=$(curl -sS -m 20 -o "$resp" -w '%{http_code}' \
-            -X POST -H 'Content-Type: application/json' -d "$payload" "$WEBHOOK" || true)
-          [ -z "$code" ] && code="000"
-          if [ "$code" = "204" ] || [ "$code" = "200" ]; then
-            echo "Discord notified (HTTP $code)."
-          else
-            echo "Discord notification FAILED with HTTP $code"
-            echo "response: $(head -c 300 "$resp")"
+
+          # Try each configured webhook until one is accepted. DISCORD_WEBHOOK_HOMELABARR
+          # was found deleted on 2026-08-11 (404 "Unknown Webhook", code 10015) — a
+          # single hard-coded webhook means one revoked URL silently disables alerting.
+          sent=false
+          for n in 1 2 3; do
+            eval "raw=\${WEBHOOK_$n:-}"
+            # Strip whitespace: a secret pasted with a trailing newline yields a URL
+            # curl cannot parse, surfacing as HTTP 000 and looking like a network fault.
+            url="$(printf '%s' "$raw" | tr -d '[:space:]')"
+            [ -z "$url" ] && continue
+            resp=$(mktemp)
+            code=$(curl -sS -m 20 -o "$resp" -w '%{http_code}' \
+              -X POST -H 'Content-Type: application/json' -d "$payload" "$url" || true)
+            [ -z "$code" ] && code="000"
+            if [ "$code" = "204" ] || [ "$code" = "200" ]; then
+              echo "Discord notified via WEBHOOK_$n (HTTP $code)."
+              sent=true; rm -f "$resp"; break
+            fi
+            echo "WEBHOOK_$n rejected: HTTP $code $(head -c 200 "$resp")"
+            rm -f "$resp"
+          done
+          if [ "$sent" != true ]; then
+            echo "::error::All Discord webhooks failed - the outage alert could NOT be delivered."
           fi
-          rm -f "$resp"


### PR DESCRIPTION
Proving AC6 end to end turned up something worth knowing: **`DISCORD_WEBHOOK_HOMELABARR` is dead.**

```
Discord notification FAILED with HTTP 404
response: {"message": "Unknown Webhook", "code": 10015}
```

The secret dates from 2026-02-21 and that webhook has since been deleted in Discord. **Anything else pointing at it has been failing silently too.**

That is the same failure shape as the outage this whole epic exists to prevent: a thing that looks configured, reports success, and reaches nobody.

## Change
Try each configured webhook in turn (`DISCORD_WEBHOOK_HOMELABARR` → `DISCORD_CICD_WEBHOOK` → `DISCORD_RLS`), log which one was accepted, and emit a workflow `::error::` if none were — so an undeliverable alert is itself loud rather than quiet.

## Progression of this investigation
| Attempt | Result | Cause |
|---|---|---|
| 1 | `Discord notification failed.` | curl output sent to /dev/null — no diagnosis possible |
| 2 | `HTTP 000`, empty body | could not connect; looked like a network fault |
| 3 | `HTTP 404 Unknown Webhook` | whitespace strip fixed parsing; real cause revealed |
| 4 | this PR | fall back across webhooks, fail loudly if all are dead |

**You will likely want to create a fresh Discord webhook and update the secret** — the fallback keeps alerting working in the meantime, but a dead secret should not be left in place.

Ticket: https://mjashley.atlassian.net/browse/HLCE-313