### PR TITLE
HLCE-317: move dev.homelabarr.com to the CE dev app

### DIFF
--- a/.github/workflows/deploy-drift.yml
+++ b/.github/workflows/deploy-drift.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
-            const LIVE_URL = 'https://ce-demo.homelabarr.com/';
+            const LIVE_URL = 'https://demo.homelabarr.com/';
             const THRESHOLD_MIN = 30;
 
             const mainCommit = await github.rest.repos.getCommit({

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -38,8 +38,8 @@ jobs:
           DEFAULT_TARGETS=(
             "https://demo.homelabarr.com/|"
             "https://demo.homelabarr.com/api/health|\"ok\":true"
-            "https://ce-dev.homelabarr.com/|"
-            "https://ce-dev.homelabarr.com/api/health|\"ok\":true"
+            "https://dev.homelabarr.com/|"
+            "https://dev.homelabarr.com/api/health|\"ok\":true"
           )
 
           if [ -n "${OVERRIDE:-}" ]; then


### PR DESCRIPTION
Completes the naming half of epic HLCE-310.

`dev.homelabarr.com` previously served the marketing site's dev environment. It now serves the CE app's dev environment, which is what people actually look for at that name.

**Done on the infrastructure side (not in this diff):**
- Traefik on ce-dev (.233) now answers for both `dev.homelabarr.com` and `ce-dev.homelabarr.com`, so nothing breaks mid-transition.
- Kingsbrooke tunnel ingress for `dev.homelabarr.com` repointed `192.168.1.234` → `192.168.1.233`. The tunnel is dashboard-managed, so DNS alone would not have moved it.
- The marketing site's dev Traefik rule was retired (renamed, not deleted) and its container stopped.

**In this diff:**
- `uptime.yml` probes `dev.homelabarr.com` instead of `ce-dev.homelabarr.com`.
- `deploy-drift.yml` compares against `demo.homelabarr.com` instead of `ce-demo.homelabarr.com` — production moved to the VPS, so the check was measuring the fallback.

**Verified live, not by reading config:**
```
dev.homelabarr.com      200   <title>HomelabARR</title>   /api/health {"ok":true}
ce-dev.homelabarr.com   200
demo.homelabarr.com     200
ce-demo.homelabarr.com  200
dev.mjashley.com / dev.imogenlabs.ai / dev.eight.ly  200 (neighbours on .234 unaffected)
```
Both drift targets still return `Last-Modified`, so the drift check keeps working.

**Rollback:** restore the tunnel config backup written on 192.168.1.195 at `/opt/appdata/compose/tunnel-config-backup-20260812T023212Z.json`, rename the `.retired-*` Traefik rule back on .234, and `docker start homelabarr-site-dev`.