### PR TITLE
HLCE-318: alert when the hypervisor disk fills or a domain pauses

### DIFF
--- a/docs/hypervisor-alerting.md
+++ b/docs/hypervisor-alerting.md
@@ -1,0 +1,138 @@
+# Hypervisor alerting
+
+Covers the two faults that took the public demo down for sixteen days in July 2026:
+the hypervisor's root filesystem filled, QEMU paused every guest with I/O errors, and a
+paused domain answered no ping and no SSH — which looks exactly like dead hardware.
+Nothing alerted, so nobody knew.
+
+Runs on **`eightly-t320-b` (192.168.1.73)**, the hypervisor hosting the CE VMs.
+
+This is the in-homelab layer. External uptime checking is separate and deliberately
+lives outside the homelab, on GitHub's infrastructure — see `.github/workflows/uptime.yml`.
+A checker inside the homelab dies with the homelab.
+
+## What it is
+
+| Piece | Path on the host |
+|---|---|
+| Script | `/usr/local/bin/homelabarr-host-alert` |
+| Config (webhook) | `/etc/homelabarr/host-alert.env`, mode 600 |
+| State | `/var/lib/homelabarr/host-alert.state` |
+| Unit | `/etc/systemd/system/homelabarr-host-alert.service` |
+| Timer | `/etc/systemd/system/homelabarr-host-alert.timer`, every 5 min |
+
+Sources of truth are in this repo under `scripts/host-alert/`.
+
+## Why it is standalone
+
+`192.168.1.73` already runs Prometheus, Alertmanager, Grafana, node-exporter and cAdvisor
+— but **that stack belongs to Eight.ly OS**, not to HomelabARR. It is installed and
+reconciled by the `eightly` binary:
+
+- `docker-compose.monitoring.yml` carries an `eightly-monitoring-schema:` marker. If the
+  file's digest matches a version Eight.ly shipped, a newer binary **replaces it**. If you
+  edit it, the box reads as operator-modified and stops receiving Eight.ly fixes
+  altogether. So the compose file is off-limits, which rules out node-exporter's textfile
+  collector for the paused-domain signal.
+- The box is on schema 5 while the installed binary ships schema 7, so it has not
+  converged — another reason not to build HomelabARR alerting on top of it.
+
+Hence: this alerting owns nothing of theirs and they own nothing of it. It needs only
+`df`, `virsh`, `curl` and `python3`.
+
+Worth knowing separately: that Alertmanager's only receiver is `default` with **no
+integrations at all**, so anything it fires today goes nowhere. That is an Eight.ly OS
+issue, not this one, but do not mistake its presence for coverage.
+
+## What it checks
+
+| Condition | Threshold | Why |
+|---|---|---|
+| Root filesystem usage | `>= 85%` | The July outage started here. `ce-prod.qcow2` is 61G and grows. |
+| Paused libvirt domains | any | A paused domain is indistinguishable from a dead box until you ask for the reason. |
+
+It is **silent while healthy**. It alerts once when a condition starts and once more when
+it clears — it does not re-post every five minutes.
+
+## It fails loudly on purpose
+
+A notifier that quietly posts into the void is worse than no notifier. Five separate
+silent failures were found on 2026-08-11, including a Discord webhook dead since February
+whose failure was swallowed by `>/dev/null`. So:
+
+- No webhook configured → exit **78**, the unit fails, and the undelivered alert is
+  written to the journal. Visible in `systemctl list-units --failed`.
+- Webhook rejects (e.g. `404 Unknown Webhook`) → exit **1**, the response body is logged,
+  and **state is not recorded** so the next run retries instead of going quiet.
+
+State is only written after a delivery actually succeeded.
+
+## Configuring the webhook
+
+```bash
+ssh root@192.168.1.73
+printf 'WEBHOOK_URL=https://discord.com/api/webhooks/...\n' > /etc/homelabarr/host-alert.env
+chmod 600 /etc/homelabarr/host-alert.env
+systemctl start homelabarr-host-alert.service
+journalctl -u homelabarr-host-alert.service -n 20 --no-pager
+```
+
+Until that URL is real, the unit fails every five minutes by design.
+
+## Verifying it — fire it, do not read it
+
+```bash
+# Healthy: silent, exit 0
+/usr/local/bin/homelabarr-host-alert; echo $?
+
+# Force the disk rule without filling the disk
+DISK_THRESHOLD=50 /usr/local/bin/homelabarr-host-alert
+
+# Prove paused-domain detection against a real pause
+virsh suspend web-dev
+virsh domstate web-dev --reason        # expect: paused (user)
+/usr/local/bin/homelabarr-host-alert
+virsh resume web-dev
+virsh domstate web-dev --reason        # expect: running (unpaused)
+```
+
+Use a dev domain (`web-dev`, `eightly-dev`) — never `ce-prod`.
+
+## When an alert fires
+
+### Paused domain
+
+**Do not conclude the hardware is dead.** That misdiagnosis is why the demo stayed dark
+for sixteen days.
+
+```bash
+ssh root@192.168.1.73
+virsh domstate <domain> --reason     # "paused (I/O error)" means the disk filled
+virsh resume <domain>
+```
+
+A resumed guest keeps a **frozen clock**, which makes TLS fail with "certificate is not
+yet valid" on every registry pull. There is no QEMU guest agent installed, so
+`virsh domtime --sync` errors. Fix it by hand on the guest:
+
+```bash
+sudo timedatectl set-ntp false
+sudo date -u -s '<current UTC time>'
+sudo timedatectl set-ntp true
+```
+
+### Disk pressure
+
+```bash
+df -h /
+du -xh --max-depth=2 /var/lib/libvirt /var/lib/docker 2>/dev/null | sort -rh | head -20
+```
+
+Retiring `ce-staging` reclaimed 40G and took the host from 91% to 73% (HLCE-314). Check
+for orphaned `.qcow2` images of destroyed domains before anything more drastic.
+
+## Related
+
+- `.github/workflows/uptime.yml` — external uptime checking (HLCE-313)
+- `.github/workflows/deploy-drift.yml` — flags a demo lagging behind `main`
+- HLCE-318 — this work; HLCE-310 — the environment consolidation epic

--- a/scripts/host-alert/homelabarr-host-alert
+++ b/scripts/host-alert/homelabarr-host-alert
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Alerts when this hypervisor is heading for the failure that took the public
+# demo down for sixteen days: the root filesystem fills, QEMU pauses the guests
+# with I/O errors, and a paused domain looks exactly like a powered-off box.
+#
+# Deliberately standalone. The Prometheus/Alertmanager stack on this host
+# belongs to Eight.ly OS — its compose file is schema-managed, and editing it
+# would mark the appliance operator-modified and stop it receiving fixes. So
+# this owns nothing of theirs and they own nothing of this.
+#
+# It is silent while healthy, alerts once when a condition starts, and says so
+# again when it clears. It does NOT swallow delivery failures: a webhook that
+# stopped working must make this unit fail visibly, because a notifier that
+# quietly posts into the void is worse than no notifier at all.
+
+set -uo pipefail
+
+ENV_FILE=${HOMELABARR_ALERT_ENV:-/etc/homelabarr/host-alert.env}
+STATE_FILE=${HOMELABARR_ALERT_STATE:-/var/lib/homelabarr/host-alert.state}
+DISK_THRESHOLD=${DISK_THRESHOLD:-85}
+MOUNT=${MOUNT:-/}
+
+# shellcheck source=/dev/null
+[ -r "$ENV_FILE" ] && . "$ENV_FILE"
+
+HOST=$(hostname)
+
+problems=()
+
+disk_pct=$(df --output=pcent "$MOUNT" | tail -1 | tr -dc '0-9')
+if [ -n "$disk_pct" ] && [ "$disk_pct" -ge "$DISK_THRESHOLD" ]; then
+  avail=$(df -h --output=avail "$MOUNT" | tail -1 | tr -d ' ')
+  problems+=("disk:${disk_pct}|Root filesystem on \`${HOST}\` is ${disk_pct}% full (${avail} free, threshold ${DISK_THRESHOLD}%). This is how the July outage started: the disk filled, QEMU paused every guest with I/O errors, and the demo stayed dark for sixteen days.")
+fi
+
+# --state-paused covers a deliberate suspend; "pmsuspended" and the I/O-error
+# pause both surface through domstate, so ask for the reason too.
+while read -r domain; do
+  [ -z "$domain" ] && continue
+  reason=$(virsh domstate "$domain" --reason 2>/dev/null | head -1)
+  problems+=("paused:${domain}|Domain \`${domain}\` on \`${HOST}\` is ${reason:-paused}. It will answer no ping and no SSH, which looks identical to dead hardware — it is not. Check \`virsh domstate ${domain} --reason\` before touching anything.")
+done < <(virsh list --state-paused --name 2>/dev/null)
+
+current_keys=$(printf '%s\n' "${problems[@]+"${problems[@]}"}" | cut -d'|' -f1 | sort | tr '\n' ' ' | sed 's/ *$//')
+previous_keys=""
+[ -r "$STATE_FILE" ] && previous_keys=$(cat "$STATE_FILE")
+
+if [ "$current_keys" = "$previous_keys" ]; then
+  exit 0   # nothing changed since the last run — stay quiet
+fi
+
+if [ -n "$current_keys" ]; then
+  body=":rotating_light: **${HOST}**"$'\n'
+  for p in "${problems[@]}"; do
+    body+=$'\n'"- ${p#*|}"
+  done
+else
+  body=":white_check_mark: **${HOST}** — cleared. Previously: ${previous_keys}"
+fi
+
+if [ -z "${WEBHOOK_URL:-}" ] || [[ "$WEBHOOK_URL" == *REPLACE_ME* ]]; then
+  echo "ALERT NOT DELIVERED — no webhook configured in ${ENV_FILE}." >&2
+  echo "Would have sent:" >&2
+  echo "$body" >&2
+  exit 78   # EX_CONFIG: the unit fails, so this is visible in systemctl
+fi
+
+payload=$(BODY="$body" python3 -c 'import json,os; print(json.dumps({"content": os.environ["BODY"]}))')
+status=$(curl -sS -o /tmp/homelabarr-host-alert.resp -w '%{http_code}' \
+  -X POST -H 'Content-Type: application/json' \
+  --max-time 15 --retry 2 --retry-delay 3 \
+  -d "$payload" "$WEBHOOK_URL")
+
+if [ "$status" != "204" ] && [ "$status" != "200" ]; then
+  echo "Discord rejected the alert: HTTP ${status} $(head -c 300 /tmp/homelabarr-host-alert.resp 2>/dev/null)" >&2
+  echo "Undelivered alert was:" >&2
+  echo "$body" >&2
+  exit 1   # do NOT record state — retry on the next run rather than go quiet
+fi
+
+mkdir -p "$(dirname "$STATE_FILE")"
+printf '%s' "$current_keys" > "$STATE_FILE"
+echo "Alert delivered (HTTP ${status}); state now: ${current_keys:-clear}"

--- a/scripts/host-alert/homelabarr-host-alert.service
+++ b/scripts/host-alert/homelabarr-host-alert.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=HomelabARR hypervisor health alert (disk pressure, paused domains)
+Documentation=https://mjashley.atlassian.net/browse/HLCE-318
+After=network-online.target libvirtd.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/homelabarr-host-alert

--- a/scripts/host-alert/homelabarr-host-alert.timer
+++ b/scripts/host-alert/homelabarr-host-alert.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run the HomelabARR hypervisor health alert every 5 minutes
+Documentation=https://mjashley.atlassian.net/browse/HLCE-318
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Unit=homelabarr-host-alert.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes the alerting half of epic HLCE-310. Covers the two faults that actually caused the sixteen-day outage: root filesystem pressure and paused libvirt domains on the hypervisor `eightly-t320-b` (192.168.1.73).

External uptime checking (HLCE-313) is already done and proven — this is the in-homelab layer that catches the *cause* rather than the symptom.

### Why standalone rather than Prometheus

`.73` already runs Prometheus, Alertmanager, Grafana and node-exporter — but **that stack belongs to Eight.ly OS**, not HomelabARR. Reading their Go source rather than assuming:

- `docker-compose.monitoring.yml` carries an `eightly-monitoring-schema:` marker and is reconciled by the `eightly` binary. Editing it makes the box read as operator-modified, which **stops it receiving Eight.ly fixes**. That rules out node-exporter's textfile collector for the paused-domain signal.
- The box sits on schema 5 while the installed binary ships schema 7, so it has not converged.

Worth flagging separately: that Alertmanager's only receiver is `default` with **no integrations at all**, so anything it fires today goes nowhere. Its presence is not coverage.

### Fails loudly on purpose

- No webhook → exit 78, unit fails, undelivered alert written to the journal.
- Webhook rejects → exit 1, response body logged, **state not recorded** so the next run retries instead of going quiet.

That is the direct lesson from the Discord webhook that had been dead since February with its failure swallowed by `>/dev/null`.

### Verified by firing it, not by reading it

| Case | Result |
|---|---|
| Healthy | silent, exit 0 |
| Disk rule (`DISK_THRESHOLD=50`) | `73% full (61G free)` — real values |
| **Paused domain** | `virsh suspend web-dev` → detected as `paused (user)` → resumed → `running (unpaused)`; dev.mjashley.com / dev.imogenlabs.ai / dev.eight.ly all back to 200 |
| Delivery | HTTP 204 against a local sink, exact JSON payload captured |
| Duplicate suppression | second run with same condition: silent |
| Recovery | `cleared. Previously: disk:73` delivered |
| Dead webhook (404 Unknown Webhook) | exit 1, logged, state left empty |

Timer is installed, enabled and active on .73, running every 5 minutes.

### Not yet proven — deliberate

`/etc/homelabarr/host-alert.env` holds `WEBHOOK_URL=REPLACE_ME`. Everything upstream of the destination URL is proven; **delivery to real Discord is not**. Until Michael supplies a webhook the unit fails every five minutes by design, which is visible rather than silent. HLCE-318 stays open for that reason.

### Rollback

```bash
systemctl disable --now homelabarr-host-alert.timer
rm /etc/systemd/system/homelabarr-host-alert.{service,timer} /usr/local/bin/homelabarr-host-alert
systemctl daemon-reload
```
Nothing owned by Eight.ly OS was touched, so there is nothing else to undo.