### PR TITLE
HLCE-318: check the webhook up front so a missing one is not silent

### DIFF
--- a/docs/hypervisor-alerting.md
+++ b/docs/hypervisor-alerting.md
@@ -60,8 +60,11 @@ A notifier that quietly posts into the void is worse than no notifier. Five sepa
 silent failures were found on 2026-08-11, including a Discord webhook dead since February
 whose failure was swallowed by `>/dev/null`. So:
 
-- No webhook configured → exit **78**, the unit fails, and the undelivered alert is
-  written to the journal. Visible in `systemctl list-units --failed`.
+- No webhook configured → exit **78** on **every** run, healthy or not, so the unit sits
+  in `systemctl list-units --failed` until it is fixed. This is checked up front on
+  purpose: checking it only when there was something to send meant a healthy host exited
+  0 without ever touching the webhook, leaving an unconfigured notifier invisible until
+  the outage it was installed to report.
 - Webhook rejects (e.g. `404 Unknown Webhook`) → exit **1**, the response body is logged,
   and **state is not recorded** so the next run retries instead of going quiet.
 

--- a/scripts/host-alert/homelabarr-host-alert
+++ b/scripts/host-alert/homelabarr-host-alert
@@ -25,6 +25,17 @@ MOUNT=${MOUNT:-/}
 
 HOST=$(hostname)
 
+# Checked up front, before anything else, and not only when there is something
+# to send. Validating it lazily meant a healthy host exited 0 without ever
+# touching the webhook, so an unconfigured notifier stayed invisible until the
+# outage it was installed to report — which is the failure mode this whole
+# thing exists to prevent.
+if [ -z "${WEBHOOK_URL:-}" ] || [[ "$WEBHOOK_URL" == *REPLACE_ME* ]]; then
+  echo "No webhook configured in ${ENV_FILE}: this host has NO alerting." >&2
+  echo "Set WEBHOOK_URL to a Discord webhook, then: systemctl start homelabarr-host-alert.service" >&2
+  exit 78   # EX_CONFIG: fails every run, so the gap shows in systemctl list-units --failed
+fi
+
 problems=()
 
 disk_pct=$(df --output=pcent "$MOUNT" | tail -1 | tr -dc '0-9')
@@ -56,13 +67,6 @@ if [ -n "$current_keys" ]; then
   done
 else
   body=":white_check_mark: **${HOST}** — cleared. Previously: ${previous_keys}"
-fi
-
-if [ -z "${WEBHOOK_URL:-}" ] || [[ "$WEBHOOK_URL" == *REPLACE_ME* ]]; then
-  echo "ALERT NOT DELIVERED — no webhook configured in ${ENV_FILE}." >&2
-  echo "Would have sent:" >&2
-  echo "$body" >&2
-  exit 78   # EX_CONFIG: the unit fails, so this is visible in systemctl
 fi
 
 payload=$(BODY="$body" python3 -c 'import json,os; print(json.dumps({"content": os.environ["BODY"]}))')


### PR DESCRIPTION
Follow-up to #466, found by firing the unit instead of trusting it.

**The defect:** on a healthy host the script exited 0 long before it reached the webhook check, because there was nothing to send. So with `WEBHOOK_URL=REPLACE_ME` the unit reported *success* every five minutes. An unconfigured notifier would have stayed completely invisible until the moment it was needed — the exact silent-failure pattern this alerting was built to end. I had claimed the opposite in #466.

**The fix:** validate the webhook before doing any work. The unit now fails on every run until a real URL is set.

Verified on 192.168.1.73:

| Case | Before | After |
|---|---|---|
| Healthy, no webhook | exit 0, looked fine | **exit 78, unit failed**, listed in `systemctl list-units --failed` |
| Healthy, real webhook | exit 0 silent | exit 0 silent (unchanged) |
| Alerting, real webhook | delivered 204 | delivered 204 (unchanged) |

Runbook corrected to match.