### PR TITLE
HLCE-320: reset the public demo on a timer so a visitor cannot break it for good

### DIFF
--- a/docs/demo-reset.md
+++ b/docs/demo-reset.md
@@ -1,0 +1,191 @@
+# Public demo reset
+
+Keeps `demo.homelabarr.com` usable by strangers.
+
+The demo is deliberately open. `DEFAULT_ADMIN_PASSWORD` is `admin` and the login screen
+tells visitors so (`src/components/LoginModal.tsx`). That is the point — it is the front
+door for the Unraid Community Apps listing (~34k pulls) and looking around should cost
+nothing.
+
+The problem is the other half. `POST /auth/change-password` (`server/routes/auth.js`) is
+guarded by `requireAuth` and **nothing else**; there is no demo-mode or read-only guard
+anywhere in `server/`. So any visitor can change the admin password and lock everyone
+else out — permanently, because the three demo volumes survive restarts, redeploys and
+Watchtower. The same applies to junk accounts and minted API keys.
+
+Nothing reset it before HLCE-320: no cron, no user crontab, no timer.
+
+Runs on **`ely-prod-01` (87.99.148.9)**, the VPS hosting the demo.
+
+## What it is
+
+| Piece | Path on the host |
+|---|---|
+| Script | `/usr/local/bin/homelabarr-demo-reset` |
+| Config (optional webhook) | `/etc/homelabarr/demo-reset.env`, mode 600 |
+| Unit | `/etc/systemd/system/homelabarr-demo-reset.service` |
+| Timer | `/etc/systemd/system/homelabarr-demo-reset.timer`, at `:07` and `:37` |
+
+Sources of truth are in this repo under `scripts/demo-reset/`.
+
+## ⛔ Why this script is written so defensively
+
+**The demo shares the Compose project name `compose` with `docker-compose.sites.yml`**, in
+the same directory, which runs **homelabarr.com, mjashley.com, eightly, imogenlabs,
+cooper-cross, agents, InvoiceNinja and Watchtower** on this same host.
+
+`docker compose down -v` or `--remove-orphans` in that project would take the production
+websites and their data down with them. **The script never uses either**, and neither
+should you when working in `/opt/appdata/compose`.
+
+There is a real architectural tension here, and it is worth stating plainly. The demo was
+moved off the homelab and denied a Docker socket (`REQUIRE_DOCKER=false`) precisely so it
+could not endanger anything. A reset that runs privileged Docker commands on the box
+serving production sites gives some of that back. It cannot be avoided outright —
+clearing a Docker volume requires Docker — so the surface is constrained instead:
+
+- **Nothing is selected by wildcard, label, prefix scan or "all".** Every container and
+  volume is named literally.
+- **Interlock 1 — the compose file.** `docker compose config --services` must return
+  exactly the two demo services. Point `COMPOSE_FILE` at `sites.yml` and the script
+  aborts instead of recreating production.
+- **Interlock 2 — the volumes.** A volume is removed only if its name is in the expected
+  list *and* `docker ps -a --filter volume=…` shows no container outside the demo
+  attached to it. A name can be mistyped; an attachment cannot be faked.
+- **Interlock 3 — the census.** Every non-demo container running before the reset must
+  still be running after it. Collateral damage fails loudly instead of exiting 0.
+- The systemd unit adds `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome` and
+  `PrivateTmp`, so everything the job does not need is taken away.
+
+## What a reset does
+
+1. Removes the **backend** container by name.
+2. Removes the three volumes by name: `compose_homelabarr-demo-{config,data,activity}`.
+   `config` holds `users.json` and `api-keys.json`; that is where the credentials live.
+3. `docker compose create` — makes the container and the volumes **without starting
+   anything**, which is the only window in which the fresh volumes can be fixed up (see
+   the landmine below).
+4. Hands the fresh volumes to the uid the container declares.
+5. `docker compose up -d --no-deps` the backend, then waits for it to report healthy.
+6. `docker compose up -d` to reconcile the rest of the stack.
+7. Waits for `https://demo.homelabarr.com/api/applications` to return `totalApps: 117`.
+8. Asserts the backend logged `creating default admin user`.
+9. Re-runs the census.
+
+A full reset takes about **13 seconds**, of which only a few are `/api` downtime.
+
+## Two landmines this uncovered
+
+Both were found by running the thing, not by reading it. Neither was visible in any
+healthy-looking output.
+
+**The demo could never be rebuilt from empty volumes.** The image ships `/app/data` and
+`/app/server/config` owned by `1001`, so Docker seeds those fresh volumes with the right
+ownership. It has **no `/app/server/activity-data` directory at all**, so Docker creates
+that volume owned by `root` — and the backend, which runs as `1001`, dies with
+`EACCES ... audit-YYYY-MM-DD.jsonl` and crash-loops. Had the VPS ever lost these volumes,
+the demo would simply not have come back. The script works around it at step 4; **the
+real fix belongs in `Dockerfile.backend`** and needs its own ticket.
+
+Worse, the failure lied about itself: the uncaught-exception handler crashed on its own
+audit insert (`SqliteError: NOT NULL constraint failed: audit_events.result`,
+`server/index.js:278` → `server/audit.js:148`), so the logs blamed SQLite rather than the
+permission error that actually killed it. Same shape as HLCE-312, still live in 2.3.0.
+
+**`pipefail` + `grep -q` made a passing check fail.** `docker logs … | grep -q …` exits at
+the first match, `docker logs` then takes `SIGPIPE` and returns 141, and `pipefail`
+reports the pipeline as failed — so the seed assertion failed *because* it matched. It is
+now matched with a here-string. Worth remembering anywhere `set -o pipefail` meets an
+early-exiting reader (`grep -q`, `head`).
+
+**The frontend is deliberately left running.** It is stateless, and recreating it would
+take the site fully down for the ~45s the backend needs to report healthy
+(`depends_on: service_healthy`) on every cycle. Only the backend is replaced, so the site
+keeps serving HTML and only `/api` blinks for a few seconds.
+
+That same `depends_on` is why step 5 passes `--no-deps`. A plain `docker compose up -d`
+evaluates the running frontend's dependency against a backend that has only just started,
+finds it still in `starting`, and exits non-zero with *"dependency failed to start:
+container homelabarr-demo-backend is unhealthy"* — which failed the reset on its very
+first run while the demo was in fact coming up perfectly well.
+
+## How the credentials are proven without logging in
+
+Step 5 is the interesting one. `initializeAuth()` in `server/auth.js` only logs
+`No users found, creating default admin user` when the user store is **empty**, and it
+then seeds from `DEFAULT_ADMIN_PASSWORD`. Seeing that line after a reset is positive
+evidence that the store was wiped and the default credentials restored — no login needed.
+
+It is **asserted, not merely noted**: a reset that clears the volumes but fails to reseed
+leaves a demo nobody can sign into, which must fail loudly.
+
+## It fails loudly on purpose
+
+Every failure names the step: `demo reset FAILED at: <step>`. The script exits non-zero,
+so the unit lands in `systemctl list-units --failed`. It never exits 0 on a broken demo.
+
+Two layers catch failures:
+
+- **The demo stops answering** → `.github/workflows/uptime.yml` alerts within 5 minutes,
+  from GitHub's infrastructure, independent of this host.
+- **The demo stays up but the reset did not work** (a refused interlock, a missing seed
+  line) → the uptime check cannot see this, so set a webhook:
+
+  ```bash
+  sudo install -d -m 755 /etc/homelabarr
+  printf 'WEBHOOK_URL=https://discord.com/api/webhooks/…\n' | sudo tee /etc/homelabarr/demo-reset.env
+  sudo chmod 600 /etc/homelabarr/demo-reset.env
+  ```
+
+  The webhook is optional here (unlike `host-alert`, which fails without one) because the
+  uptime check already covers the loud half. Delivery problems are reported, never
+  swallowed, and never mask the original failure.
+
+## Install
+
+```bash
+sudo install -m 755 scripts/demo-reset/homelabarr-demo-reset /usr/local/bin/
+sudo install -m 644 scripts/demo-reset/homelabarr-demo-reset.service /etc/systemd/system/
+sudo install -m 644 scripts/demo-reset/homelabarr-demo-reset.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now homelabarr-demo-reset.timer
+```
+
+`enable` is what makes it survive a reboot. `Persistent=true` means a reset missed while
+the box was down runs once on boot.
+
+## Operating it
+
+```bash
+# Reset right now (e.g. someone reports the demo is broken)
+sudo systemctl start homelabarr-demo-reset.service
+
+# Did the last one work?
+systemctl status homelabarr-demo-reset.service
+journalctl -u homelabarr-demo-reset.service -n 50
+
+# When does it run next?
+systemctl list-timers homelabarr-demo-reset.timer
+
+# Anything failing on this host?
+systemctl list-units --failed
+```
+
+## Rollback
+
+```bash
+sudo systemctl disable --now homelabarr-demo-reset.timer
+sudo rm -f /etc/systemd/system/homelabarr-demo-reset.{service,timer} \
+           /usr/local/bin/homelabarr-demo-reset
+sudo systemctl daemon-reload
+```
+
+The demo keeps running — removing the timer only stops it being reset.
+
+## Known gap
+
+This bounds the damage; it does not prevent it. A visitor who changes the admin password
+still breaks the demo for up to 30 minutes. The durable fix is a demo/read-only mode in
+the server that rejects mutations of the admin account, which is a product change and a
+separate ticket. Do not close that gap by changing the demo credentials or putting the
+demo behind auth — being open is the point.

--- a/scripts/demo-reset/homelabarr-demo-reset
+++ b/scripts/demo-reset/homelabarr-demo-reset
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Restores demo.homelabarr.com to its pristine state.
+#
+# The demo is deliberately open: DEFAULT_ADMIN_PASSWORD is admin and the login
+# screen tells visitors to sign in with admin/admin. That is by design — it is
+# the front door for the Unraid Community Apps listing and it should cost a
+# visitor nothing to look around. The other half of that bargain is this script.
+# Nothing in the server stops a visitor changing the admin password:
+# /auth/change-password is behind requireAuth and nothing else. Without a reset,
+# the first person to change it locks everyone else out of the demo forever, and
+# the same goes for junk accounts and minted API keys.
+#
+# ── DANGER, READ BEFORE EDITING ──────────────────────────────────────────────
+# The demo shares the Compose project name "compose" with docker-compose.sites.yml
+# in the same directory, which runs homelabarr.com, mjashley.com, eightly,
+# imogenlabs, cooper-cross, agents, InvoiceNinja and Watchtower on this same host.
+# `docker compose down -v` or `--remove-orphans` in that project would take the
+# production websites and their data with it. So this script NEVER uses either.
+#
+# It cannot be made unprivileged — clearing a Docker volume needs Docker — so
+# instead the surface is constrained. Every object is named literally; nothing is
+# selected by wildcard, label or "all". Three interlocks refuse to proceed if
+# reality does not match those names:
+#
+#   1. the compose file must define exactly the two demo services, so pointing
+#      COMPOSE_FILE at sites.yml aborts instead of recreating production;
+#   2. a volume is removed only if its name is in the expected list AND no
+#      container outside the demo is attached to it;
+#   3. every non-demo container running before the reset must still be running
+#      after it, so collateral damage fails loudly instead of exiting 0.
+#
+# The frontend is deliberately left alone. It is stateless — all demo state lives
+# in the backend's three volumes — and recreating it would take the site fully
+# down for the ~45s the backend needs to report healthy, every cycle, which would
+# also trip the 5-minute uptime check. Only the backend is replaced, so the site
+# keeps serving HTML and only /api blinks for a few seconds.
+
+set -uo pipefail
+
+COMPOSE_FILE=${COMPOSE_FILE:-/opt/appdata/compose/docker-compose.homelabarr-demo.yml}
+
+# Pinned explicitly. Compose derives the project name from the compose file's
+# directory, so it is "compose" today — but if that ever drifted, `up` would
+# create a second set of volumes under a new prefix and quietly leave the ones
+# this script just cleared, resetting nothing.
+PROJECT=${PROJECT:-compose}
+
+BACKEND=homelabarr-demo-backend
+FRONTEND=homelabarr-demo-frontend
+DEMO_CONTAINERS=("$BACKEND" "$FRONTEND")
+DEMO_SERVICES=(homelabarr-demo-backend homelabarr-demo-frontend)
+VOLUMES=(
+  compose_homelabarr-demo-config
+  compose_homelabarr-demo-data
+  compose_homelabarr-demo-activity
+)
+
+HEALTH_URL=${HEALTH_URL:-https://demo.homelabarr.com/api/applications}
+EXPECT_APPS=${EXPECT_APPS:-117}
+HEALTH_TRIES=${HEALTH_TRIES:-30}
+
+ENV_FILE=${HOMELABARR_DEMO_RESET_ENV:-/etc/homelabarr/demo-reset.env}
+# shellcheck source=/dev/null
+[ -r "$ENV_FILE" ] && . "$ENV_FILE"
+
+# Every failure names the step that broke. A reset that exits 0 on a demo that
+# is still broken is worse than no reset at all — it is the silent-failure shape
+# this project has been bitten by repeatedly.
+die() {
+  local step="$1"
+  echo "demo reset FAILED at: ${step}" >&2
+
+  # Best effort. A webhook is optional here because the every-5-minute uptime
+  # check already alerts when the demo stops answering; this only makes the
+  # failures that leave the demo *up* (a refused interlock, a missing seed)
+  # visible too. Delivery problems are reported, never swallowed, and never
+  # allowed to mask the original failure.
+  local url
+  url="$(printf '%s' "${WEBHOOK_URL:-}" | tr -d '[:space:]')"
+  if [ -n "$url" ]; then
+    local payload code
+    payload=$(printf '{"content":"**demo reset FAILED** on %s at step: %s"}' \
+      "$(hostname)" "${step//\"/}")
+    code=$(curl -sS -m 20 -o /dev/null -w '%{http_code}' \
+      -X POST -H 'Content-Type: application/json' -d "$payload" "$url" || true)
+    case "${code:-000}" in
+      200|204) ;;
+      *) echo "warning: could not deliver the failure alert (HTTP ${code:-000})" >&2 ;;
+    esac
+  fi
+  exit 1
+}
+
+# ── interlock 1: the compose file is the demo's, and only the demo's ─────────
+[ -r "$COMPOSE_FILE" ] || die "compose file ${COMPOSE_FILE} is unreadable"
+
+services=$(docker compose -f "$COMPOSE_FILE" config --services 2>/dev/null | sort | tr '\n' ' ')
+services=${services% }
+expected=$(printf '%s\n' "${DEMO_SERVICES[@]}" | sort | tr '\n' ' ')
+expected=${expected% }
+[ "$services" = "$expected" ] \
+  || die "compose file defines '${services}', expected exactly '${expected}' — refusing to touch it"
+
+# ── interlock 2a: the volume names are the demo's ────────────────────────────
+for v in "${VOLUMES[@]}"; do
+  case "$v" in
+    compose_homelabarr-demo-*) ;;
+    *) die "refusing to remove unexpected volume '${v}'" ;;
+  esac
+done
+
+is_demo_container() {
+  local name="$1"
+  for c in "${DEMO_CONTAINERS[@]}"; do [ "$name" = "$c" ] && return 0; done
+  return 1
+}
+
+# Everything running on this host that is not the demo. Recorded before the
+# reset and compared after it.
+census() {
+  docker ps --format '{{.Names}}' \
+    | grep -vxF -e "$BACKEND" -e "$FRONTEND" \
+    | sort
+}
+
+before=$(census) || die "could not list running containers"
+[ -n "$before" ] || die "container census came back empty — docker is not answering properly"
+echo "== non-demo containers running before the reset: $(printf '%s\n' "$before" | wc -l | tr -d ' ')"
+
+echo "== replacing the demo backend =="
+docker rm -f "$BACKEND" >/dev/null 2>&1
+docker inspect "$BACKEND" >/dev/null 2>&1 && die "container ${BACKEND} could not be removed"
+
+echo "== clearing the demo volumes =="
+for v in "${VOLUMES[@]}"; do
+  # interlock 2b: the real protection. A name can be mistyped; an attachment
+  # cannot be faked. If anything outside the demo has this volume mounted, the
+  # name list is wrong and removing it would destroy someone else's data.
+  attached=$(docker ps -a --filter "volume=${v}" --format '{{.Names}}')
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    is_demo_container "$name" || die "volume ${v} is attached to non-demo container '${name}'"
+  done <<< "$attached"
+
+  docker volume rm "$v" >/dev/null 2>&1
+  docker volume inspect "$v" >/dev/null 2>&1 && die "volume ${v} survived removal"
+done
+
+# No `down`, no `-v`, no `--remove-orphans` anywhere below — see the header.
+# Every compose call is scoped by the compose file, which interlock 1 has
+# already proven is the demo's.
+compose() { docker compose -p "$PROJECT" -f "$COMPOSE_FILE" "$@"; }
+
+# `create` makes the container and the volumes without starting anything, which
+# is the only window in which the volumes can be fixed up before the backend
+# tries to use them.
+echo "== creating the demo backend and its volumes =="
+# stdout is noise, stderr is the reason it failed — never suppress the latter.
+compose create "$BACKEND" >/dev/null || die "compose create"
+
+# The image ships /app/data and /app/server/config owned by 1001, so Docker
+# seeds those fresh volumes with the right ownership. It has no
+# /app/server/activity-data at all, so Docker creates that one owned by root —
+# and the backend, which runs as 1001, dies with EACCES on its first audit
+# write. Worse, the uncaught-exception handler then crashes on its own audit
+# insert (NOT NULL constraint failed: audit_events.result), so the log blames
+# SQLite rather than the permission error.
+#
+# The demo could therefore never be rebuilt from empty volumes — this script
+# found that out the first time it ran. The real fix belongs in the image; until
+# it lands, make the fresh volumes usable by the user the container declares.
+owner=$(docker inspect -f '{{.Config.User}}' "$BACKEND" 2>/dev/null)
+[ -n "$owner" ] || die "could not read the uid the backend runs as"
+for v in "${VOLUMES[@]}"; do
+  mp=$(docker volume inspect -f '{{.Mountpoint}}' "$v" 2>/dev/null)
+  # chown -R on a path this script did not verify would be a very bad day.
+  case "$mp" in
+    /var/lib/docker/volumes/"$v"/_data) ;;
+    *) die "volume ${v} has an unexpected mountpoint '${mp}'" ;;
+  esac
+  chown "$owner" "$mp" || die "could not give ${v} to ${owner}"
+done
+
+echo "== starting the demo backend =="
+# --no-deps because the frontend is already running and declares
+# `depends_on: condition: service_healthy`. Without it, compose evaluates that
+# dependency against a backend that has only just started, finds it still in
+# `starting`, and exits non-zero with "dependency failed to start" — failing the
+# reset every single run while the demo was in fact coming up fine.
+compose up -d --no-deps "$BACKEND" || die "compose up backend"
+
+echo "== waiting for the backend to report healthy =="
+healthy=false
+for _ in $(seq 1 "$HEALTH_TRIES"); do
+  state=$(docker inspect -f '{{.State.Health.Status}}' "$BACKEND" 2>/dev/null)
+  [ "$state" = "healthy" ] && { healthy=true; break; }
+  # Crash-looping is terminal, not something waiting will fix.
+  restarts=$(docker inspect -f '{{.RestartCount}}' "$BACKEND" 2>/dev/null)
+  [ "${restarts:-0}" -gt 3 ] && die "the backend is crash-looping (${restarts} restarts) — check: docker logs ${BACKEND}"
+  sleep 5
+done
+[ "$healthy" = true ] || die "the backend never reported healthy within $((HEALTH_TRIES * 5))s"
+
+echo "== reconciling the rest of the stack =="
+# Now that the backend is healthy the frontend's dependency is satisfiable, so
+# this is a no-op when the frontend is already up and recreates it when it is not.
+compose up -d || die "compose up"
+
+echo "== waiting for the demo to serve the catalogue =="
+ok=false
+for _ in $(seq 1 "$HEALTH_TRIES"); do
+  body=$(curl -fsS --max-time 10 "$HEALTH_URL" 2>/dev/null)
+  if [ -n "$body" ]; then
+    # One sed rather than a grep|head|grep chain: `head` closing the pipe early
+    # is the same pipefail trap as above.
+    total=$(sed -n 's/.*"totalApps"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p' <<< "$body")
+    [ "${total:-0}" = "$EXPECT_APPS" ] && { ok=true; break; }
+  fi
+  sleep 5
+done
+[ "$ok" = true ] || die "the demo did not serve ${EXPECT_APPS} apps within $((HEALTH_TRIES * 5))s"
+
+# Proves the default credentials are back WITHOUT logging in. This line is only
+# reachable when the user store is empty (server/auth.js initializeAuth), so it
+# is positive evidence that the store was wiped and reseeded from
+# DEFAULT_ADMIN_PASSWORD. Asserted, not merely noted: a reset that clears the
+# volumes but does not reseed leaves a demo nobody can sign into.
+echo "== confirming the default admin was reseeded =="
+# Captured into a variable and matched with a here-string on purpose. Piping
+# into `grep -q` looks equivalent and is not: grep exits at the first match,
+# `docker logs` takes SIGPIPE and returns 141, and `pipefail` reports the whole
+# pipeline as failed — so the check failed *because* it matched, and the reset
+# died at the last step every run.
+backend_log=$(docker logs "$BACKEND" 2>&1) || die "could not read the backend log"
+grep -qi 'default admin user' <<< "$backend_log" \
+  || die "the backend never logged the default admin seed — credentials may not be restored"
+
+# ── interlock 3: nothing else on this host was harmed ────────────────────────
+after=$(census) || die "could not list running containers after the reset"
+lost=$(comm -23 <(printf '%s\n' "$before") <(printf '%s\n' "$after"))
+[ -z "$lost" ] || die "collateral damage — these non-demo containers stopped: ${lost//$'\n'/, }"
+
+echo "demo reset OK — ${EXPECT_APPS} apps served, default credentials reseeded, $(printf '%s\n' "$after" | wc -l | tr -d ' ') non-demo containers untouched"

--- a/scripts/demo-reset/homelabarr-demo-reset.service
+++ b/scripts/demo-reset/homelabarr-demo-reset.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Reset the HomelabARR public demo to its pristine state
+Documentation=https://mjashley.atlassian.net/browse/HLCE-320
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/homelabarr-demo-reset
+
+# This unit needs the Docker socket on a host that also runs production
+# websites, so it cannot be unprivileged. Everything it does NOT need is taken
+# away instead: it writes nothing to disk, gets no new privileges, and cannot
+# see the rest of the filesystem.
+NoNewPrivileges=true
+ProtectSystem=strict
+# The one exception to the read-only filesystem: fresh Docker volumes come back
+# root-owned and have to be handed to the uid the backend runs as. Scoped to the
+# volume tree and nothing else.
+ReadWritePaths=/var/lib/docker/volumes
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+LockPersonality=true

--- a/scripts/demo-reset/homelabarr-demo-reset.timer
+++ b/scripts/demo-reset/homelabarr-demo-reset.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=Reset the HomelabARR public demo every 30 minutes
+Documentation=https://mjashley.atlassian.net/browse/HLCE-320
+
+[Timer]
+# Every 30 minutes, so the worst case for a visitor who changes the admin
+# password is half an hour of a broken demo rather than forever.
+#
+# Offset off the hour on purpose: the uptime check runs at */5, and the reset
+# blinks /api for a few seconds while the backend restarts. The check retries
+# three times before alerting, so it rides this out — the offset just keeps the
+# two from lining up habitually.
+OnCalendar=*-*-* *:07,37:00
+Persistent=true
+AccuracySec=30s
+Unit=homelabarr-demo-reset.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes [HLCE-320](https://mjashley.atlassian.net/browse/HLCE-320).

## Why

`demo.homelabarr.com` publishes `admin` / `admin` on its own login screen. That is by design — it is the front door for the Unraid Community Apps listing and looking around should cost a visitor nothing.

The other half of that bargain was missing. `POST /auth/change-password` is guarded by `requireAuth` and **nothing else**, and the three demo volumes survive restarts, redeploys and Watchtower. The first visitor to change the admin password locked everyone else out **permanently**. Same for junk accounts and minted API keys. Nothing reset it: no cron, no user crontab, no timer.

A systemd timer now clears the demo's three volumes and rebuilds the backend every 30 minutes, bounding the damage at half an hour.

## ⛔ Why the script is written so defensively

The demo shares the Compose project name `compose` with `docker-compose.sites.yml` on the same host, which runs **homelabarr.com, mjashley.com, eightly, imogenlabs, cooper-cross, agents, InvoiceNinja and Watchtower**. `docker compose down -v` or `--remove-orphans` there would take the production sites and their data with them. **Neither appears anywhere in this script.**

Clearing a Docker volume needs Docker, so the privilege cannot be removed — the surface is constrained instead. Nothing is selected by wildcard, label or "all"; every object is named literally, and three interlocks refuse to proceed if reality does not match those names. All three were fired against the live host, not just written:

| Interlock | Proof |
|---|---|
| Compose file must define exactly the two demo services | Pointed at `docker-compose.sites.yml` → `refusing to touch it`, named all 7 production services, exit 1, all 13 non-demo containers still running |
| Volume must have no non-demo container attached | Parked a throwaway container on `compose_homelabarr-demo-data` → `volume … is attached to non-demo container 'hlce320-squatter'`, exit 1 |
| Every non-demo container running before must still be running after | Asserted every run; verified by construction, never fired |

The unit adds `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome` and `PrivateTmp`, with a single `ReadWritePaths=/var/lib/docker/volumes` exemption.

## Proven by breaking it, not by reading it

Tampered the live demo the way a visitor can — replaced the admin password hash, added a junk admin account, minted a junk API key, planted sentinel files — then ran the timer unit:

```
== non-demo containers running before the reset: 13
== replacing the demo backend ==
== clearing the demo volumes ==
== creating the demo backend and its volumes ==
== starting the demo backend ==
== waiting for the backend to report healthy ==
== reconciling the rest of the stack ==
== waiting for the demo to serve the catalogue ==
== confirming the default admin was reseeded ==
demo reset OK — 117 apps served, default credentials reseeded, 13 non-demo containers untouched
```

`Result=success`, 13s wall time. After: junk account gone, `api-keys.json` back to `{}`, sentinels gone, all three volumes recreated, fresh admin seeded with a new id and a new bcrypt hash, `/` and `/api/applications` both 200 with `totalApps: 117`, and all 13 production containers still showing their original uptimes.

Credentials are proven reseeded **without logging in**: `initializeAuth()` only logs `No users found, creating default admin user` when the user store is empty, so that line is positive evidence of a wipe-and-reseed. The script asserts it rather than noting it.

## Two landmines this uncovered

Neither was visible in any healthy-looking output. Both need follow-up tickets.

**The demo could never be rebuilt from empty volumes.** The image has no `/app/server/activity-data`, so Docker creates that volume `root`-owned while the backend runs as `1001` → `EACCES` → crash loop. Had the VPS ever lost those volumes, the demo would not have come back. Worked around here; **the real fix belongs in `Dockerfile.backend`**. The failure also lied about itself — the uncaught-exception handler crashed on its own audit insert (`NOT NULL constraint failed: audit_events.result`) and blamed SQLite. Same shape as HLCE-312, still live in 2.3.0.

**`pipefail` + `grep -q` fails when it matches.** `docker logs | grep -q` — grep exits at the first match, `docker logs` takes SIGPIPE and returns 141, `pipefail` reports failure. The seed assertion failed *because* it succeeded. Now matched with a here-string.

## Known gap

This bounds the damage, it does not prevent it. A visitor still breaks the demo for up to 30 minutes. The durable fix is a read-only/demo mode in the server that rejects mutations of the admin account — a product change, and a separate ticket. Not closed by changing the demo credentials or putting the demo behind auth: being open is the point.

## Rollback

```bash
sudo systemctl disable --now homelabarr-demo-reset.timer
sudo rm -f /etc/systemd/system/homelabarr-demo-reset.{service,timer} /usr/local/bin/homelabarr-demo-reset
sudo systemctl daemon-reload
```