### PR TITLE
HLCE-321: add a demo mode that refuses account changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Found a vulnerability? Email **michael@mjashley.com** — see [SECURITY.md](SECU
 | `CORS_ORIGIN` | **Yes** | The URL you open the dashboard at. |
 | `DEFAULT_ADMIN_PASSWORD` | Optional | Default is `admin` — change it. |
 | `AUDIT_ANCHOR_KEY` | Optional | Signs the audit log's out-of-band tamper-evidence anchor. Falls back to `JWT_SECRET` if unset. |
+| `DEMO_MODE` | Optional | Off unless you set it to `true`. For public demos where everyone shares one login: refuses password changes, user management, API keys and MFA so no visitor can lock everyone else out. |
 | `TZ` | Optional | Your timezone. Defaults to `America/New_York`. |
 
 All options: [wiki.homelabarr.com/guides/configuration](https://wiki.homelabarr.com/guides/configuration/)

--- a/docs/demo-reset.md
+++ b/docs/demo-reset.md
@@ -182,10 +182,17 @@ sudo systemctl daemon-reload
 
 The demo keeps running — removing the timer only stops it being reset.
 
-## Known gap
+## The gap this used to leave, now closed
 
-This bounds the damage; it does not prevent it. A visitor who changes the admin password
-still breaks the demo for up to 30 minutes. The durable fix is a demo/read-only mode in
-the server that rejects mutations of the admin account, which is a product change and a
-separate ticket. Do not close that gap by changing the demo credentials or putting the
-demo behind auth — being open is the point.
+This bounds damage; on its own it does not prevent it — a visitor who changed the admin
+password still broke the demo until the next reset. That hole is now closed separately by
+**`DEMO_MODE`** (HLCE-321), which makes the server refuse account changes outright:
+password changes, user create/delete, API key mint/revoke and MFA setup. See
+`server/demo-mode.js`.
+
+The two are complements, not alternatives. The guard stops the lockout; this reset still
+clears the junk that accumulates in a public demo and puts it back to a known state. Keep
+both.
+
+Neither is closed by changing the demo credentials or putting the demo behind auth —
+being open is the point.

--- a/server/demo-mode.js
+++ b/server/demo-mode.js
@@ -1,0 +1,46 @@
+// Demo mode — refuses the handful of actions that could lock everyone else out
+// of a shared, publicly-signed-in HomelabARR.
+//
+// The public demo hands out admin / admin on its own login screen, which is the
+// point: anyone should be able to look around. The cost is that any visitor
+// could change that password, delete the admin, or turn on MFA with a secret
+// only they hold — and everyone after them is locked out. A scheduled reset
+// bounds that damage to half an hour; this closes it.
+//
+// ── Rules for anyone touching this ──────────────────────────────────────────
+//
+// OFF UNLESS EXPLICITLY ON. This code ships to every self-hosted install. With
+// DEMO_MODE unset — which is every real install — `demoGuard` calls next() and
+// behaves exactly as it did before this file existed. Only the literal strings
+// "true" and "1" turn it on.
+//
+// IT ONLY EVER ADDS A REFUSAL. It never relaxes an existing check. Mount it
+// AFTER requireAuth / requireRole on protected routes, so an unauthenticated
+// caller still gets the 401 it has always got, and the refusal only ever
+// replaces a would-be success.
+//
+// ONE CHOKEPOINT. The gate is this middleware and the list of routes it is
+// mounted on — not conditionals sprinkled through auth logic. To see what is
+// gated, grep for demoGuard.
+
+// Read at call time, not at import time: a module-level snapshot makes the
+// behaviour depend on import order and is a nuisance to test.
+export function isDemoMode() {
+  const raw = String(process.env.DEMO_MODE ?? '').trim().toLowerCase();
+  return raw === 'true' || raw === '1';
+}
+
+// Written for a stranger looking at a browser notification, not for an operator
+// reading a log: say what happened, why, and what to do about it.
+export const DEMO_REFUSAL =
+  'This is the public HomelabARR demo, so changes to accounts are switched off — ' +
+  'everyone signs in with admin / admin. Install HomelabARR on your own machine to ' +
+  'change passwords, manage users, set up MFA or mint API keys.';
+
+export function demoGuard(req, res, next) {
+  if (!isDemoMode()) return next();
+  // 403, not 401: the caller is who they say they are and is allowed to be here
+  // — this instance simply will not do it. `code` lets the UI branch on it
+  // without matching prose.
+  return res.status(403).json({ error: DEMO_REFUSAL, code: 'demo_mode' });
+}

--- a/server/routes/auth-admin.js
+++ b/server/routes/auth-admin.js
@@ -24,6 +24,7 @@ import { logActivity, getActivities } from '../activity-logger.js';
 import { getUserStars, addStar, removeStar } from '../stars.js';
 import transporter from '../email.js';
 import { readSecret } from '../secrets.js';
+import { demoGuard } from '../demo-mode.js';
 
 export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopment, logger }) {
   const router = Router();
@@ -54,7 +55,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
   });
 
   // R3: Forgot password — send reset email
-  router.post('/auth/forgot-password', rateLimit({ windowMs: 60 * 60 * 1000, max: 5 }), async (req, res) => {
+  router.post('/auth/forgot-password', rateLimit({ windowMs: 60 * 60 * 1000, max: 5 }), demoGuard, async (req, res) => {
     const { username } = req.body || {};
     const user = username ? findUserByUsername(username) : null;
     if (user?.email) {
@@ -74,7 +75,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
   });
 
   // R3: Reset password — consume reset token and update password
-  router.post('/auth/reset-password', rateLimit({ windowMs: 15 * 60 * 1000, max: 10 }), async (req, res) => {
+  router.post('/auth/reset-password', rateLimit({ windowMs: 15 * 60 * 1000, max: 10 }), demoGuard, async (req, res) => {
     try {
       const { user_id, token, new_password } = req.body || {};
       if (!user_id || !token || !new_password) return res.status(400).json({ error: 'Missing fields' });
@@ -100,7 +101,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
   });
 
   // Admin-only user management routes
-  router.post('/auth/users', requireAuth, requireRole('admin'), async (req, res) => {
+  router.post('/auth/users', requireAuth, requireRole('admin'), demoGuard, async (req, res) => {
     try {
       const { username, email, password, role } = req.body;
 
@@ -143,7 +144,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
     res.json(sanitizedUsers);
   });
 
-  router.delete('/auth/users/:userId', requireAuth, requireRole('admin'), (req, res) => {
+  router.delete('/auth/users/:userId', requireAuth, requireRole('admin'), demoGuard, (req, res) => {
     try {
       const { userId } = req.params;
 
@@ -180,7 +181,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
     }
   });
 
-  router.put('/auth/users/:userId/password', requireAuth, requireRole('admin'), async (req, res) => {
+  router.put('/auth/users/:userId/password', requireAuth, requireRole('admin'), demoGuard, async (req, res) => {
     try {
       const { userId } = req.params;
       const { newPassword } = req.body;
@@ -241,7 +242,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
   });
 
   // ─── API Key Routes ─────────────────────────────────────────────────────
-  router.post('/auth/api-keys', requireAuth, async (req, res) => {
+  router.post('/auth/api-keys', requireAuth, demoGuard, async (req, res) => {
     try {
       const { label } = req.body;
       const entry = createApiKey(req.user.id, label);
@@ -261,7 +262,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
     res.json({ apiKeys: listApiKeys(req.user.id) });
   });
 
-  router.delete('/auth/api-keys/:keyId', requireAuth, (req, res) => {
+  router.delete('/auth/api-keys/:keyId', requireAuth, demoGuard, (req, res) => {
     const success = revokeApiKey(req.params.keyId, req.user.id);
     if (success) res.json({ message: 'API key revoked' });
     else res.status(404).json({ error: 'API key not found' });
@@ -313,7 +314,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
     }
   });
 
-  router.post('/auth/register', requireAuth, requireRole('admin'), async (req, res) => {
+  router.post('/auth/register', requireAuth, requireRole('admin'), demoGuard, async (req, res) => {
     try {
       const { username, password, email, role } = req.body;
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -14,6 +14,7 @@ import {
   loadSessions,
   invalidateSession,
 } from '../auth.js';
+import { demoGuard } from '../demo-mode.js';
 import {
   createSession,
   rotateRefresh,
@@ -185,7 +186,7 @@ export default function authRoutes({ sendError, getRequestMeta, loginLimiter, lo
     });
   });
 
-  router.post('/auth/change-password', requireAuth, async (req, res) => {
+  router.post('/auth/change-password', requireAuth, demoGuard, async (req, res) => {
     try {
       const { currentPassword, newPassword } = req.body;
 
@@ -335,7 +336,7 @@ export default function authRoutes({ sendError, getRequestMeta, loginLimiter, lo
   });
 
   // R3: MFA setup — generate TOTP secret + QR code
-  router.post('/auth/mfa/setup', requireAuth, async (req, res) => {
+  router.post('/auth/mfa/setup', requireAuth, demoGuard, async (req, res) => {
     try {
       if (req.body && Object.keys(req.body).length > 0) {
         return res.status(400).json({ error: 'This endpoint does not accept a request body' });
@@ -351,7 +352,7 @@ export default function authRoutes({ sendError, getRequestMeta, loginLimiter, lo
   });
 
   // R3: MFA verify — confirm TOTP code and enable MFA
-  router.post('/auth/mfa/verify', requireAuth, async (req, res) => {
+  router.post('/auth/mfa/verify', requireAuth, demoGuard, async (req, res) => {
     try {
       const { code } = req.body || {};
       if (typeof code !== 'string' || !/^[0-9]{6}$/.test(code)) {
@@ -374,7 +375,7 @@ export default function authRoutes({ sendError, getRequestMeta, loginLimiter, lo
   });
 
   // R3: MFA disable — requires password confirmation
-  router.post('/auth/mfa/disable', requireAuth, async (req, res) => {
+  router.post('/auth/mfa/disable', requireAuth, demoGuard, async (req, res) => {
     try {
       const { password } = req.body || {};
       if (typeof password !== 'string' || password.length === 0) {

--- a/server/routes/demo-mode.routes.test.js
+++ b/server/routes/demo-mode.routes.test.js
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// HLCE-321: integration tests for demo mode, driven end-to-end through the real
+// Express app. Same harness as auth.routes.test.js — env is set before index.js
+// is imported, and the app/db are a per-file singleton.
+//
+// Demo mode is read per request (server/demo-mode.js reads process.env at call
+// time, not at import), so a test can flip it between requests against the same
+// running app. That is the whole point of these tests: the SAME app must behave
+// two different ways, and the "off" way must be indistinguishable from before.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hlce-demomode-'));
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'x'.repeat(40);
+process.env.DB_PATH = ':memory:';
+process.env.CONFIG_DIR = tmp;
+process.env.DATA_DIR = tmp;
+process.env.AUDIT_DIR = path.join(tmp, 'audit');
+process.env.SECRET_ROOT = path.join(tmp, 'no-secrets');
+process.env.BCRYPT_COST = '4';
+process.env.RATE_LIMIT_DISABLED = 'true';
+delete process.env.SMTP_HOST;
+delete process.env.DEMO_MODE;
+
+let request, app, auth, demoMode;
+
+beforeAll(async () => {
+  request = (await import('supertest')).default;
+  app = (await import('../index.js')).app;
+  auth = await import('../auth.js');
+  demoMode = await import('../demo-mode.js');
+  await auth.createUser({ username: 'demoboss', email: 'demoboss@x.com', password: 'demobosspass12', role: 'admin' });
+  await auth.createUser({ username: 'switcher', email: 'switcher@x.com', password: 'switcherpass12', role: 'admin' });
+});
+
+afterEach(() => { delete process.env.DEMO_MODE; });
+
+function csrfOf(setCookie) {
+  const line = (setCookie || []).find(c => c.startsWith('hl_csrf='));
+  return line ? line.split(';')[0].split('=')[1] : undefined;
+}
+
+async function login(username, password) {
+  const agent = request.agent(app);
+  const res = await agent.post('/auth/login').send({ username, password });
+  return { agent, csrf: csrfOf(res.headers['set-cookie']), status: res.status };
+}
+
+function mutate(sess, method, url) {
+  return sess.agent[method](url)
+    .set('x-csrf-token', sess.csrf)
+    .set('x-requested-with', 'XMLHttpRequest');
+}
+
+const hashOf = (username) =>
+  auth.loadUsers().find(u => u.username === username)?.password;
+
+describe('isDemoMode (off unless explicitly on)', () => {
+  // This is the single most important behaviour in the file: this code ships to
+  // every self-hosted install, and anything other than an explicit opt-in must
+  // leave them exactly as they were.
+  it('is off when DEMO_MODE is unset', () => {
+    delete process.env.DEMO_MODE;
+    expect(demoMode.isDemoMode()).toBe(false);
+  });
+
+  it.each(['false', 'False', '0', '', 'no', 'off', 'yes-please', 'TRUEISH'])(
+    'is off for DEMO_MODE=%j', (value) => {
+      process.env.DEMO_MODE = value;
+      expect(demoMode.isDemoMode()).toBe(false);
+    });
+
+  it.each(['true', 'TRUE', 'True', ' true ', '1'])(
+    'is on for DEMO_MODE=%j', (value) => {
+      process.env.DEMO_MODE = value;
+      expect(demoMode.isDemoMode()).toBe(true);
+    });
+});
+
+describe('DEMO_MODE off — behaviour is unchanged (AC1)', () => {
+  it('lets a user actually change their password, and the stored hash changes', async () => {
+    const sess = await login('switcher', 'switcherpass12');
+    expect(sess.status).toBe(200);
+
+    const before = hashOf('switcher');
+    const res = await mutate(sess, 'post', '/auth/change-password')
+      .send({ currentPassword: 'switcherpass12', newPassword: 'switcherpass34' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(hashOf('switcher')).not.toBe(before);
+  });
+
+  it('still enforces its own validation, not a demo refusal', async () => {
+    const sess = await login('demoboss', 'demobosspass12');
+    const res = await mutate(sess, 'post', '/auth/change-password')
+      .send({ currentPassword: 'demobosspass12', newPassword: 'short' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBeUndefined();
+  });
+});
+
+describe('DEMO_MODE on — account-destroying actions are refused', () => {
+  it('refuses a password change and leaves the stored hash untouched (AC2)', async () => {
+    const sess = await login('demoboss', 'demobosspass12');
+    process.env.DEMO_MODE = 'true';
+
+    const before = hashOf('demoboss');
+    expect(before).toBeTruthy();
+
+    const res = await mutate(sess, 'post', '/auth/change-password')
+      .send({ currentPassword: 'demobosspass12', newPassword: 'a-perfectly-valid-new-password' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('demo_mode');
+    // The point of the whole ticket: not just an error, but no write.
+    expect(hashOf('demoboss')).toBe(before);
+  });
+
+  it('refuses user create, delete, admin password reset and register (AC3)', async () => {
+    const sess = await login('demoboss', 'demobosspass12');
+    const victim = auth.loadUsers().find(u => u.username === 'switcher');
+    process.env.DEMO_MODE = 'true';
+
+    // Sequential on purpose: a supertest agent reuses one connection, and firing
+    // these concurrently resets it.
+    const attempts = [
+      () => mutate(sess, 'post', '/auth/users').send({ username: 'newbie', email: 'n@x.com', password: 'newbiepass12' }),
+      () => mutate(sess, 'post', '/auth/register').send({ username: 'newbie2', email: 'n2@x.com', password: 'newbiepass12' }),
+      () => mutate(sess, 'delete', `/auth/users/${victim.id}`),
+      () => mutate(sess, 'put', `/auth/users/${victim.id}/password`).send({ new_password: 'someone-elses-password' }),
+    ];
+
+    for (const attempt of attempts) {
+      const res = await attempt();
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('demo_mode');
+    }
+    // Nobody was created and nobody was deleted.
+    expect(auth.loadUsers().some(u => u.username === 'newbie')).toBe(false);
+    expect(auth.loadUsers().some(u => u.username === 'newbie2')).toBe(false);
+    expect(auth.loadUsers().some(u => u.id === victim.id)).toBe(true);
+  });
+
+  it('refuses API key mint and revoke, and MFA setup/verify/disable (AC4)', async () => {
+    const sess = await login('demoboss', 'demobosspass12');
+    process.env.DEMO_MODE = 'true';
+
+    const attempts = [
+      () => mutate(sess, 'post', '/auth/api-keys').send({ label: 'sneaky' }),
+      () => mutate(sess, 'delete', '/auth/api-keys/any-key-id'),
+      () => mutate(sess, 'post', '/auth/mfa/setup'),
+      () => mutate(sess, 'post', '/auth/mfa/verify').send({ code: '123456' }),
+      () => mutate(sess, 'post', '/auth/mfa/disable').send({ password: 'demobosspass12' }),
+    ];
+
+    for (const attempt of attempts) {
+      const res = await attempt();
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('demo_mode');
+    }
+  });
+
+  it('refuses the unauthenticated password-reset flow, which writes a password hash directly', async () => {
+    // Not on the original list. forgot-password/reset-password bypass
+    // change-password entirely and write users[idx].password, so leaving them
+    // open would leave the lockout hole half-closed.
+    process.env.DEMO_MODE = 'true';
+
+    const forgot = await request(app).post('/auth/forgot-password').send({ username: 'demoboss' });
+    expect(forgot.status).toBe(403);
+    expect(forgot.body.code).toBe('demo_mode');
+
+    const before = hashOf('demoboss');
+    const reset = await request(app).post('/auth/reset-password')
+      .send({ user_id: 'x', token: 'y', new_password: 'another-long-password' });
+    expect(reset.status).toBe(403);
+    expect(reset.body.code).toBe('demo_mode');
+    expect(hashOf('demoboss')).toBe(before);
+  });
+
+  it('gives a human-readable reason, not a bare status (AC5)', async () => {
+    const sess = await login('demoboss', 'demobosspass12');
+    process.env.DEMO_MODE = 'true';
+
+    const res = await mutate(sess, 'post', '/auth/change-password')
+      .send({ currentPassword: 'demobosspass12', newPassword: 'a-perfectly-valid-new-password' });
+
+    expect(res.status).toBe(403);
+    expect(typeof res.body.error).toBe('string');
+    expect(res.body.error.length).toBeGreaterThan(40);
+    expect(res.body.error).toMatch(/demo/i);
+    // Tells the visitor what to do rather than just saying no.
+    expect(res.body.error).toMatch(/install|your own/i);
+  });
+
+  it('still lets the demo demonstrate the product (AC6)', async () => {
+    const sess = await login('demoboss', 'demobosspass12');
+    process.env.DEMO_MODE = 'true';
+
+    // Signing in has to keep working or there is no demo at all.
+    const fresh = await login('demoboss', 'demobosspass12');
+    expect(fresh.status).toBe(200);
+
+    const reads = [];
+    for (const url of ['/auth/me', '/auth/users', '/auth/api-keys', '/auth/sessions', '/applications']) {
+      reads.push(await sess.agent.get(url));
+    }
+    for (const res of reads) {
+      expect(res.status).toBe(200);
+    }
+    // The catalogue is the demo's whole shop window.
+    const catalog = reads[4];
+    expect(catalog.body.totalApps ?? Object.keys(catalog.body.applications || {}).length).toBeTruthy();
+  });
+
+  it('does not stand in front of the auth check it sits behind', async () => {
+    // demoGuard is mounted AFTER requireAuth, so an anonymous caller must still
+    // be told it is unauthenticated — the refusal replaces a success, never a 401.
+    process.env.DEMO_MODE = 'true';
+    const res = await request(app).post('/auth/change-password')
+      .set('x-requested-with', 'XMLHttpRequest')
+      .send({ currentPassword: 'a', newPassword: 'b-long-enough-password' });
+
+    expect([401, 403]).toContain(res.status);
+    expect(res.body.code).not.toBe('demo_mode');
+  });
+});

--- a/src/components/ApiKeysModal.tsx
+++ b/src/components/ApiKeysModal.tsx
@@ -35,6 +35,18 @@ export function ApiKeysModal({ isOpen, onClose }: ApiKeysModalProps) {
   const getCsrfToken = () =>
     document.cookie.match(/(?:^|; )hl_csrf=([^;]+)/)?.[1] || '';
 
+  // Prefer the server's own explanation over a generic one. A refusal that says
+  // why (a demo instance declining account changes, say) is worth showing; both
+  // handlers below used to drop it, and revoke said nothing at all.
+  const reasonFrom = async (res: Response, fallback: string) => {
+    try {
+      const data = await res.json();
+      return typeof data?.error === "string" && data.error ? data.error : fallback;
+    } catch {
+      return fallback;
+    }
+  };
+
   const fetchKeys = async () => {
     if (!isAuthenticated) return;
     setLoading(true);
@@ -83,7 +95,7 @@ export function ApiKeysModal({ isOpen, onClose }: ApiKeysModalProps) {
         success("API Key Created", "Copy it now — it won't be shown again.");
         fetchKeys();
       } else {
-        error("Error", "Failed to create API key");
+        error("Error", await reasonFrom(res, "Failed to create API key"));
       }
     } catch {
       error("Error", "Failed to create API key");
@@ -106,6 +118,8 @@ export function ApiKeysModal({ isOpen, onClose }: ApiKeysModalProps) {
       if (res.ok) {
         success("Revoked", "API key has been revoked");
         fetchKeys();
+      } else {
+        error("Error", await reasonFrom(res, "Failed to revoke API key"));
       }
     } catch {
       error("Error", "Failed to revoke API key");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,10 +141,10 @@ export default defineConfig({
       // (898 tests). Floor raised with conservative headroom (statements/functions ~1 under
       // for CI under-instrumentation safety).
       thresholds: {
-        lines: 82,
-        statements: 81,
-        functions: 80,
-        branches: 74,
+        lines: 83,
+        statements: 82,
+        functions: 83,
+        branches: 75,
       },
     },
     // Two projects: backend (server/**) in node, frontend (src/**) in jsdom.

--- a/wiki/docs/guides/configuration.md
+++ b/wiki/docs/guides/configuration.md
@@ -27,6 +27,7 @@ Optional, but useful:
 | `TZ` | `UTC` | Your timezone (e.g., `America/New_York`, `Europe/London`) |
 | `AUTH_ENABLED` | `true` | Set to `false` to disable the login screen |
 | `AUDIT_ANCHOR_KEY` | falls back to `JWT_SECRET` | Signs the tamper-evident audit log's out-of-band chain-tip anchor. Leave unset to reuse `JWT_SECRET`; set a dedicated random value (`openssl rand -hex 32`) to keep audit integrity independent of JWT key rotation. |
+| `DEMO_MODE` | `false` | Only for a public demo where everyone shares one login. Set to `true` and the server refuses changes to accounts — password changes, creating or deleting users, minting or revoking API keys, and setting up or disabling MFA — so no visitor can lock everyone else out. Everything else, including the app catalog, containers and logs, works normally. Leave it unset on a real install. |
 
 !!! danger "Don't disable auth on a networked server"
     Setting `AUTH_ENABLED=false` removes the login screen and exposes all API endpoints — including container management and user administration — to anyone who can reach your server. Only use this in isolated local testing environments.


### PR DESCRIPTION
Closes [HLCE-321](https://mjashley.atlassian.net/browse/HLCE-321). The durable fix for the hole [HLCE-320](https://mjashley.atlassian.net/browse/HLCE-320) could only bound.

## Why

The demo publishes `admin` / `admin` on its own login screen — that is the point. The cost was that any visitor could change that password, delete the admin, or enable MFA with a secret only they held, and everyone after them was locked out. The reset timer bounds that to 30 minutes. This closes it.

## The overriding constraint: don't break real installs

**`DEMO_MODE` is off unless it is explicitly `true` or `1`.** With it unset — every real install — `demoGuard` calls `next()` and behaves exactly as before. There are 13 test cases pinning that parsing alone (`false`, `0`, `""`, `no`, `off`, `TRUEISH`, … all off).

**It only ever adds a refusal.** The guard is mounted *after* `requireAuth` and `requireRole`, so it can only replace a would-be success. Proven on a live server: with demo mode ON, an anonymous caller still gets `401`, and a viewer hitting `POST /auth/users` still gets `Insufficient permissions` — not the demo refusal.

**One chokepoint.** `server/demo-mode.js` is 40 lines; the gate is that middleware plus the routes it is mounted on. To see what is gated, `grep demoGuard`.

## What I gated, and how I chose it

I enumerated `server/routes/` rather than working from the supplied list, which turned up **two routes that were not on it**:

- `POST /auth/forgot-password` and `POST /auth/reset-password` write `users[idx].password` **directly**, bypassing `change-password` entirely. Leaving them open would have left the lockout hole half-closed.

12 routes gated: change-password · users create/delete/register · admin password reset · api-keys mint/revoke · mfa setup/verify/disable · forgot-password/reset-password.

**Deliberately not gated**, with reasons:

| Left alone | Why |
|---|---|
| `DELETE /auth/sessions/:jti`, `revoke-all` | Scoped to the caller's *own* sessions (`session.user_id !== userId → 404`). A visitor can only log themselves out. |
| `POST /auth/me/stars/:appId` | Cosmetic per-user favourites — part of the demo experience. |
| `POST /auth/cli-mint` | Operator-key gated, mints `viewer`/`scanner` only, ttl ≤ 1h. No lockout, no escalation. |
| Container / deploy / enhanced-mount | Account safety is this ticket's scope, and the demo has no Docker socket, so they are already inert. Gating them would shrink what the demo demonstrates. |

## Proven by firing real HTTP at a real server (AC7)

A standalone `node server/index.js`, both modes, same requests. **No password was entered anywhere** — the session is a jti-less JWT minted through `/auth/cli-mint` with the operator key.

```
──────── DEMO_MODE off ────────
  POST /auth/change-password  -> 400  {"error":"User not found"}
  POST /auth/api-keys         -> 201  {"id":"key_6a3e…","key":"hlr_9ffe…"}      <- really minted a key
  POST /auth/mfa/setup        -> 200  {"uri":"otpauth://totp/…"}                 <- really issued a secret
  POST /auth/reset-password   -> 400  {"error":"Invalid or expired token"}
  POST /auth/users            -> 403  {"error":"Insufficient permissions"}
  GET  /applications          -> 200

──────── DEMO_MODE on ────────
  POST /auth/change-password  -> 403  {"error":"This is the public HomelabARR demo…"}
  POST /auth/api-keys         -> 403  demo_mode
  POST /auth/mfa/setup        -> 403  demo_mode
  POST /auth/reset-password   -> 403  demo_mode
  POST /auth/users            -> 403  {"error":"Insufficient permissions"}       <- still authz, not demo
  GET  /applications          -> 200
```

The `201 → 403` and `200 → 403` transitions are the load-bearing ones: those actions genuinely succeeded with the guard off.

## Tests

23 new cases in `server/routes/demo-mode.routes.test.js`, both modes through the real Express app. **AC2 asserts the stored bcrypt hash is byte-identical after the refusal**, not merely that an error came back — and that with demo mode off the same request *does* change it.

Full suite **929 passed / 62 files**. Coverage ratcheted **82/81/80/74 → 83/82/83/75** (actual 84.47 lines / 83.68 stmts / 84.19 funcs / 76.43 branches).

## Frontend

Zero changes needed for password/user flows — `UserSettings` already surfaces `errorData.error`. `ApiKeysModal` was the exception: generic text on create, **silence** on revoke. It now shows the reason it is given. There is no MFA UI in `src/` (API-only).

## Rollback

Remove `DEMO_MODE` from the demo's compose environment and recreate the backend. The code is inert without it.