### PR TITLE
HLCE-307: bucket IPv6 login attempts by subnet instead of exact address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "cors": "^2.8.5",
         "dockerode": "^5.0.1",
         "express": "^5.2.1",
-        "express-rate-limit": "^7.1.5",
+        "express-rate-limit": "^8.6.2",
         "helmet": "^8.3.0",
         "ipaddr.js": "^2.5.0",
         "jsonwebtoken": "^9.0.2",
@@ -2155,25 +2155,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
@@ -7011,10 +6992,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -7906,7 +7891,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
       "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cors": "^2.8.5",
     "dockerode": "^5.0.1",
     "express": "^5.2.1",
-    "express-rate-limit": "^7.1.5",
+    "express-rate-limit": "^8.6.2",
     "helmet": "^8.3.0",
     "ipaddr.js": "^2.5.0",
     "jsonwebtoken": "^9.0.2",

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ import { initializeActivityLog, logActivity } from './activity-logger.js';
 import { initAudit, audit, verifyChain } from './audit.js';
 import { maybeAlert, setAuditHook } from './alert.js';
 import { logger as structuredLogger, requestContext } from './log.js';
-import { createLoginLimiter, createLockoutGuard } from './ratelimit.js';
+import { createLoginLimiter, createLockoutGuard, ipSubnetKey } from './ratelimit.js';
 import { createCrashHandlers } from './crash.js';
 import { attackTag } from './middleware/attackTag.js';
 import { mountHoney } from './routes/honey.js';
@@ -144,6 +144,7 @@ const globalRateLimit = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later.' },
+  keyGenerator: ipSubnetKey,
   // Disabled only when explicitly opted in (E2E harness drives many requests from
   // a single IP). Never set in production.
   skip: () => process.env.RATE_LIMIT_DISABLED === 'true',

--- a/server/ratelimit.js
+++ b/server/ratelimit.js
@@ -1,5 +1,16 @@
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { db } from './db.js';
+
+// An IPv6 client is delegated a whole subnet, not one address, and can rotate
+// freely inside it. Keying a limiter on the exact address therefore handed an
+// attacker a fresh bucket on every request and made the login limit meaningless
+// over IPv6 (HLCE-307). ipKeyGenerator collapses an IPv6 address to its /56
+// prefix — the block an ISP hands a single subscriber — and returns IPv4
+// addresses untouched, so IPv4 stays bucketed per address exactly as before.
+// Use this for EVERY limiter key: a raw `req.ip` key is the bug.
+export function ipSubnetKey(req) {
+  return ipKeyGenerator(req.ip ?? '');
+}
 
 export class SqliteStore {
   constructor(windowMs) {
@@ -48,7 +59,7 @@ export function createLoginLimiter() {
     max: 25,
     standardHeaders: true,
     legacyHeaders: false,
-    keyGenerator: (req) => 'login:' + req.ip,
+    keyGenerator: (req) => 'login:' + ipSubnetKey(req),
     store: new SqliteStore(15 * 60 * 1000),
     skipSuccessfulRequests: true,
     // Disabled only when explicitly opted in (E2E harness). Never set in production.

--- a/server/ratelimit.test.js
+++ b/server/ratelimit.test.js
@@ -347,3 +347,96 @@ describe('RATE_LIMIT_DISABLED escape hatch (AC5)', () => {
     expect(guard2.isLocked('carol')).toBe(true); // lockout survived
   });
 });
+
+// HLCE-307: the login limiter used to key on the exact client address
+// (`'login:' + req.ip`). An IPv6 client is delegated a whole subnet and can
+// rotate addresses inside it at will, so every attempt landed in a fresh
+// bucket and the 25-per-15-minutes limit never bit. These tests drive real
+// requests through the limiter from many source addresses.
+//
+// Source addresses are varied with X-Forwarded-For behind `trust proxy`, which
+// is how req.ip is populated on the real deployment (the app sits behind
+// Traefik). Without the fix, `ipv6Requests` below never sees a 429.
+function proxiedApp(limiter, statusFor) {
+  const app = express();
+  app.set('trust proxy', true);
+  app.post('/login', limiter, (_req, res) => res.status(statusFor()).json({}));
+  return app;
+}
+
+// Fires `count` failed logins, each from a different address produced by
+// `addressFor(i)`, and reports how many were rejected with a 429.
+async function attemptsFrom(app, count, addressFor) {
+  let blocked = 0;
+  for (let i = 0; i < count; i++) {
+    const r = await request(app).post('/login').set('X-Forwarded-For', addressFor(i));
+    if (r.status === 429) blocked++;
+  }
+  return blocked;
+}
+
+describe('IPv6 subnet bucketing (HLCE-307)', () => {
+  it('shares one bucket across addresses rotating within a single /64', async () => {
+    const { createLoginLimiter } = await loadRl();
+    const app = proxiedApp(createLoginLimiter(), () => 401);
+    const { db } = await import('./db.js');
+
+    // 40 attempts, every one from a DIFFERENT address inside 2001:db8:: — the
+    // exact rotation an attacker gets for free on IPv6. The limit is 25, so
+    // the last 15 must be rejected.
+    const blocked = await attemptsFrom(app, 40, (i) => `2001:db8::${(i + 1).toString(16)}`);
+    expect(blocked).toBe(15);
+
+    // ...and they landed in ONE bucket, not 40.
+    const keys = db.prepare('SELECT key FROM rate_buckets').all().map(r => r.key);
+    expect(keys).toEqual(['login:2001:db8::/56']);
+  });
+
+  it('keeps separate buckets for clients in different subnets', async () => {
+    const { createLoginLimiter } = await loadRl();
+    const app = proxiedApp(createLoginLimiter(), () => 401);
+    const { db } = await import('./db.js');
+
+    // One attacker burns their whole allowance...
+    expect(await attemptsFrom(app, 25, () => '2001:db8::1')).toBe(0);
+    // ...which must not touch an unrelated client in another subnet.
+    expect(await attemptsFrom(app, 1, () => '2001:db9::1')).toBe(0);
+
+    const keys = db.prepare('SELECT key FROM rate_buckets').all().map(r => r.key).sort();
+    expect(keys).toEqual(['login:2001:db8::/56', 'login:2001:db9::/56']);
+  });
+
+  it('leaves IPv4 bucketed per address, unchanged (25 per window)', async () => {
+    const { createLoginLimiter } = await loadRl();
+    const app = proxiedApp(createLoginLimiter(), () => 401);
+    const { db } = await import('./db.js');
+
+    // 30 attempts from one IPv4 address: 25 allowed, 5 blocked — the behaviour
+    // that shipped before this fix.
+    expect(await attemptsFrom(app, 30, () => '203.0.113.7')).toBe(5);
+    // A different IPv4 address is a different client and keeps its own bucket:
+    // no subnet aggregation is applied to IPv4.
+    expect(await attemptsFrom(app, 1, () => '203.0.113.8')).toBe(0);
+
+    const keys = db.prepare('SELECT key FROM rate_buckets').all().map(r => r.key).sort();
+    expect(keys).toEqual(['login:203.0.113.7', 'login:203.0.113.8']);
+  });
+});
+
+describe('ipSubnetKey (HLCE-307)', () => {
+  it('collapses IPv6 to its subnet, passes IPv4 through, and tolerates a missing ip', async () => {
+    const { ipSubnetKey } = await loadRl();
+    // Two addresses in one /64 (and a third in the same /56) collapse together.
+    expect(ipSubnetKey({ ip: '2001:db8::1' })).toBe('2001:db8::/56');
+    expect(ipSubnetKey({ ip: '2001:db8::dead:beef' })).toBe('2001:db8::/56');
+    expect(ipSubnetKey({ ip: '2001:db8:0:1::1' })).toBe('2001:db8::/56');
+    // A different subnet stays distinct.
+    expect(ipSubnetKey({ ip: '2001:db9::1' })).not.toBe('2001:db8::/56');
+    // IPv4 is untouched, including the IPv4-mapped IPv6 form Node hands us on
+    // a dual-stack socket.
+    expect(ipSubnetKey({ ip: '203.0.113.7' })).toBe('203.0.113.7');
+    expect(ipSubnetKey({ ip: '::ffff:203.0.113.7' })).toBe('203.0.113.7');
+    // req.ip is undefined when Express cannot determine it; key rather than throw.
+    expect(ipSubnetKey({})).toBe('');
+  });
+});

--- a/server/routes/auth-admin.js
+++ b/server/routes/auth-admin.js
@@ -3,6 +3,7 @@ import express from 'express';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import rateLimit from 'express-rate-limit';
+import { ipSubnetKey } from '../ratelimit.js';
 import {
   requireAuth,
   requireRole,
@@ -55,7 +56,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
   });
 
   // R3: Forgot password — send reset email
-  router.post('/auth/forgot-password', rateLimit({ windowMs: 60 * 60 * 1000, max: 5 }), demoGuard, async (req, res) => {
+  router.post('/auth/forgot-password', rateLimit({ windowMs: 60 * 60 * 1000, max: 5, keyGenerator: ipSubnetKey }), demoGuard, async (req, res) => {
     const { username } = req.body || {};
     const user = username ? findUserByUsername(username) : null;
     if (user?.email) {
@@ -75,7 +76,7 @@ export default function authAdminRoutes({ sendError, getRequestMeta, isDevelopme
   });
 
   // R3: Reset password — consume reset token and update password
-  router.post('/auth/reset-password', rateLimit({ windowMs: 15 * 60 * 1000, max: 10 }), demoGuard, async (req, res) => {
+  router.post('/auth/reset-password', rateLimit({ windowMs: 15 * 60 * 1000, max: 10, keyGenerator: ipSubnetKey }), demoGuard, async (req, res) => {
     try {
       const { user_id, token, new_password } = req.body || {};
       if (!user_id || !token || !new_password) return res.status(400).json({ error: 'Missing fields' });


### PR DESCRIPTION
Fixes the login rate limiter's IPv6 bypass and takes the express-rate-limit 8.6.2 bump that was held pending it (supersedes #445).

## The bug

`keyGenerator: (req) => 'login:' + req.ip` keys on the exact client address. An IPv6 client is delegated a whole subnet and can rotate addresses inside it freely, so every attempt landed in a fresh bucket.

Measured against the code on `main`, 40 login attempts from 40 different addresses inside `2001:db8::/64`:

```
401 401 401 401 401 ... 401   (40x — not one rejection)
buckets: login:2001:db8::1, login:2001:db8::2, ... 40 separate rows
```

## After

```
401 x25, then 429 x15
buckets: login:2001:db8::/56 | 40
         login:2001:db9::/56 | 1   (different subnet, unaffected)
```

## What changed

- `ipSubnetKey(req)` in `server/ratelimit.js` wraps v8's `ipKeyGenerator`: IPv6 collapses to its /56 prefix (the block an ISP delegates to one subscriber, and strictly broader than the /64 the ticket asked for), IPv4 passes through whole.
- Applied to the login limiter, and explicitly to the global / forgot-password / reset-password limiters, which were leaning on the library default. No limiter now derives a key from a raw address.
- express-rate-limit 7.5.1 -> 8.6.2. v8's validator flagged the old generator as `ERR_ERL_KEY_GEN_IPV6`; a real boot on this branch logs no such warning.

IPv4 behaviour is unchanged: still per-address, still 25 per 15 minutes.

## Evidence

- 3 new limiter tests + 1 helper test drive real HTTP through the real limiter and real SQLite store. Reverting just the key generator fails 2 of them (`expected +0 to be 15`), so they pin the bug rather than the fix.
- Verified out-of-process with curl against a real listening server (numbers above), not only via the test harness.
- Live backend boot: limiter fires at 25 (429), bucket key `login:127.0.0.1` — IPv4 untouched.
- Full suite: 933 passed / 62 files. Coverage 84.52 lines / 83.76 stmts / 84.21 funcs / 76.52 branches, all above the 83/82/83/75 gate.

Closes HLCE-307.