### PR TITLE
HLCE-312: report the crash before trying to record it

### DIFF
--- a/server/crash.js
+++ b/server/crash.js
@@ -1,0 +1,104 @@
+// Process-level crash handlers.
+//
+// By the time anything in here runs, something has already gone wrong, and the
+// handler's only remaining job is to make sure the operator learns WHAT. It
+// failed at exactly that once (HLCE-312): the uncaughtException handler wrote
+// an audit row BEFORE logging the error, that insert threw on its own NOT NULL
+// constraint, and the resulting SQLite stack buried the real fault — an EACCES
+// on the activity-data volume — under an unrelated database error. The first
+// diagnosis went looking at the database.
+//
+// Two rules follow from that, and both are load-bearing:
+//
+//   1. Report the original error, with its stack, FIRST and unconditionally.
+//   2. Everything after that is best-effort and individually guarded. A failure
+//      while recording the crash may add a line; it may never replace or
+//      suppress the line above it.
+//
+// Rule 2 is not hypothetical: the audit sink writes to the same filesystem that
+// may be the thing that just broke, so the recording step is a genuine
+// candidate to fail during precisely the crashes that matter most.
+
+// Errors are truncated before they reach a log sink or the audit meta. A crash
+// stack is unbounded and the audit row is JSON in a SQLite column.
+const MESSAGE_LIMIT = 500;
+const STACK_LIMIT = 4000;
+
+// `throw 'a string'` is legal, and a crash handler is the last place that should
+// assume it got a well-formed Error.
+function describe(err) {
+  if (err instanceof Error) {
+    return {
+      message: (err.message || err.name || 'Error').slice(0, MESSAGE_LIMIT),
+      stack: (err.stack || '').slice(0, STACK_LIMIT),
+    };
+  }
+  return { message: String(err).slice(0, MESSAGE_LIMIT), stack: '' };
+}
+
+/**
+ * Builds the uncaughtException / unhandledRejection handlers.
+ *
+ * Everything the handlers touch is injected so the crash path can be driven in
+ * a test with a sink that throws — the case that caused HLCE-312 and that the
+ * old in-index.js handlers could not be tested for at all.
+ */
+export function createCrashHandlers({ logger, audit, exit, onUncaught, onUnhandled, exitDelayMs = 100 }) {
+  // The guaranteed floor. structuredLogger writes through winston transports,
+  // which is itself I/O that can fail on a broken filesystem, so the original
+  // error also goes to stderr directly if the structured write throws. Better
+  // reported twice than lost once.
+  function report(event, described) {
+    try {
+      logger.error(event, { message: described.message, stack: described.stack });
+    } catch {
+      console.error(`[${event}] ${described.message}\n${described.stack}`);
+    }
+  }
+
+  // Best-effort. The caller has ALREADY reported the original error by the time
+  // this runs, so a throw in here is logged as the secondary failure it is and
+  // then dropped. It must never propagate: an exception thrown from inside an
+  // uncaughtException handler is fatal and takes the process down with the
+  // wrong error attached.
+  function tryAudit(evt) {
+    try {
+      // `result` is NOT NULL in the audit schema. Omitting it is what turned a
+      // crash report into a second crash (HLCE-312).
+      audit({ actor: 'system', result: 'error', ...evt });
+      return true;
+    } catch (auditErr) {
+      const described = describe(auditErr);
+      report('audit_write_failed_during_crash', {
+        message: described.message,
+        stack: described.stack,
+      });
+      return false;
+    }
+  }
+
+  function handleUncaughtException(err) {
+    onUncaught?.();
+    const described = describe(err);
+    // FIRST, and outside every guard below.
+    report('uncaught_exception', described);
+    tryAudit({
+      event: 'process.uncaught_exception',
+      meta: { message: described.message, stack: described.stack.slice(0, MESSAGE_LIMIT) },
+    });
+    // Unchanged: a short delay so the log sinks can flush, then a non-zero exit.
+    setTimeout(() => exit(1), exitDelayMs);
+  }
+
+  function handleUnhandledRejection(reason) {
+    onUnhandled?.();
+    const described = describe(reason);
+    report('unhandled_rejection', described);
+    tryAudit({
+      event: 'process.unhandled_rejection',
+      meta: { message: described.message, stack: described.stack.slice(0, MESSAGE_LIMIT) },
+    });
+  }
+
+  return { handleUncaughtException, handleUnhandledRejection };
+}

--- a/server/crash.test.js
+++ b/server/crash.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createCrashHandlers } from './crash.js';
+
+// HLCE-312. The production incident: a fresh volume on ely-prod-01 was not
+// writable, the backend died with an EACCES, and the uncaughtException handler
+// then called audit() without a `result` — NOT NULL — so the handler crashed
+// too. What surfaced was a SqliteError about a constraint, and the EACCES that
+// actually caused the outage was buried above it.
+//
+// These tests drive the handlers with an audit sink that throws, which is what
+// the old in-index.js handlers could not be tested for: they were registered
+// inside `if (process.env.NODE_ENV !== 'test')`.
+
+const EACCES = "EACCES: permission denied, open '/app/server/activity-data/audit-2026-08-12.jsonl'";
+
+// Collects everything the handler reported, in order.
+function recordingLogger() {
+  const calls = [];
+  return { calls, error: (event, fields) => calls.push({ event, ...fields }) };
+}
+
+// The audit sink as it behaved during the incident.
+function constraintFailingAudit() {
+  return vi.fn(() => {
+    throw new Error('NOT NULL constraint failed: audit_events.result');
+  });
+}
+
+// The exit is deliberately deferred so the log sinks can flush, so the tests
+// drive the timer rather than racing it.
+function setup({ audit = vi.fn(), logger = recordingLogger() } = {}) {
+  vi.useFakeTimers();
+  const exit = vi.fn();
+  const handlers = createCrashHandlers({ logger, audit, exit, exitDelayMs: 100 });
+  const runExitTimer = () => vi.advanceTimersByTime(100);
+  return { handlers, logger, audit, exit, runExitTimer };
+}
+
+afterEach(() => { vi.useRealTimers(); });
+
+describe('uncaught exception handler (HLCE-312)', () => {
+  it('reports the original error, with its stack, before touching the audit log', () => {
+    const { handlers, logger, audit } = setup();
+    handlers.handleUncaughtException(new Error(EACCES));
+
+    // The original error is the FIRST thing reported, not something that has to
+    // survive a later step.
+    expect(logger.calls[0].event).toBe('uncaught_exception');
+    expect(logger.calls[0].message).toBe(EACCES);
+    expect(logger.calls[0].stack).toContain('Error: EACCES: permission denied');
+    // ...and it was reported before the audit write was attempted.
+    expect(audit).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the original error when the audit insert throws, and does not rethrow', () => {
+    const audit = constraintFailingAudit();
+    const { handlers, logger, exit, runExitTimer } = setup({ audit });
+
+    // The handler must not throw: an exception raised inside an
+    // uncaughtException handler is fatal and re-attributes the crash.
+    expect(() => handlers.handleUncaughtException(new Error(EACCES))).not.toThrow();
+
+    // AC3: the permission error is still named as the cause.
+    expect(logger.calls[0]).toMatchObject({ event: 'uncaught_exception', message: EACCES });
+
+    // The audit failure is reported as the secondary event it is — after the
+    // original, clearly labelled, and NOT as 'uncaught_exception'.
+    expect(logger.calls[1].event).toBe('audit_write_failed_during_crash');
+    expect(logger.calls[1].message).toContain('NOT NULL constraint failed');
+
+    // Nothing else replaced the original report.
+    expect(logger.calls).toHaveLength(2);
+    expect(logger.calls.filter(c => c.event === 'uncaught_exception')).toHaveLength(1);
+
+    // AC4: the process still exits non-zero.
+    runExitTimer();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('supplies a non-null result so the audit insert does not fail in the first place', () => {
+    const { handlers, audit } = setup();
+    handlers.handleUncaughtException(new Error(EACCES));
+
+    const row = audit.mock.calls[0][0];
+    // The column is NOT NULL; omitting it is the original bug.
+    expect(row.result).toBe('error');
+    expect(row.result).not.toBeNull();
+    expect(row).toMatchObject({ event: 'process.uncaught_exception', actor: 'system' });
+    // The crash detail now travels in `meta`, which audit() actually persists —
+    // the old handler passed a top-level `message` key that audit() ignored, so
+    // the reason never reached the row at all.
+    expect(row.meta.message).toBe(EACCES);
+  });
+
+  it('still exits non-zero when the logger itself is broken', () => {
+    // The incident was a filesystem permission error, and winston transports
+    // write to that same filesystem. Losing the log must not cost the exit.
+    const logger = { error: () => { throw new Error('log sink is gone'); } };
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { handlers, exit, runExitTimer } = setup({ logger });
+
+    expect(() => handlers.handleUncaughtException(new Error(EACCES))).not.toThrow();
+    // Falls back to stderr so the original error is still visible.
+    expect(spy.mock.calls.flat().join(' ')).toContain(EACCES);
+    runExitTimer();
+    expect(exit).toHaveBeenCalledWith(1);
+    spy.mockRestore();
+  });
+
+  it('survives a thrown non-Error', () => {
+    const { handlers, logger, exit, runExitTimer } = setup();
+    expect(() => handlers.handleUncaughtException('just a string')).not.toThrow();
+    expect(logger.calls[0].message).toBe('just a string');
+    runExitTimer();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('unhandled rejection handler (HLCE-312)', () => {
+  it('supplies a non-null result and survives a failing audit sink', () => {
+    // AC5: the rejection handler had the same missing-`result` defect as the
+    // exception handler.
+    const audit = constraintFailingAudit();
+    const { handlers, logger } = setup({ audit });
+
+    expect(() => handlers.handleUnhandledRejection(new Error('boom'))).not.toThrow();
+    expect(logger.calls[0]).toMatchObject({ event: 'unhandled_rejection', message: 'boom' });
+    expect(logger.calls[1].event).toBe('audit_write_failed_during_crash');
+  });
+
+  it('records a non-null result on the audit row', () => {
+    const { handlers, audit } = setup();
+    handlers.handleUnhandledRejection(new Error('boom'));
+    expect(audit.mock.calls[0][0]).toMatchObject({
+      event: 'process.unhandled_rejection', actor: 'system', result: 'error',
+    });
+  });
+
+  it('does not exit the process', () => {
+    // Unchanged behaviour: only uncaughtException is fatal.
+    const { handlers, exit } = setup();
+    handlers.handleUnhandledRejection(new Error('boom'));
+    expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+describe('audit row is actually insertable (HLCE-312 AC1)', () => {
+  it('inserts against the real audit schema without a constraint error', async () => {
+    // The unit tests above use a stub sink. This one drives the REAL audit()
+    // against the real NOT NULL schema, which is what actually blew up.
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hlce-crash-'));
+    vi.resetModules();
+    process.env.DB_PATH = ':memory:';
+    process.env.DATA_DIR = tmp;
+    process.env.SECRET_ROOT = path.join(tmp, 'no-secrets');
+
+    const { audit, initAudit } = await import('./audit.js');
+    const { db } = await import('./db.js');
+    initAudit();
+    const handlers = createCrashHandlers({
+      logger: recordingLogger(), audit, exit: vi.fn(), exitDelayMs: 0,
+    });
+
+    expect(() => handlers.handleUncaughtException(new Error(EACCES))).not.toThrow();
+
+    const row = db.prepare(
+      "SELECT event, actor, result, meta_json FROM audit_events WHERE event = 'process.uncaught_exception'"
+    ).get();
+    expect(row).toBeDefined();
+    expect(row.result).toBe('error');
+    expect(JSON.parse(row.meta_json).message).toBe(EACCES);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+    for (const k of ['DB_PATH', 'DATA_DIR', 'SECRET_ROOT']) delete process.env[k];
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ import { initAudit, audit, verifyChain } from './audit.js';
 import { maybeAlert, setAuditHook } from './alert.js';
 import { logger as structuredLogger, requestContext } from './log.js';
 import { createLoginLimiter, createLockoutGuard } from './ratelimit.js';
+import { createCrashHandlers } from './crash.js';
 import { attackTag } from './middleware/attackTag.js';
 import { mountHoney } from './routes/honey.js';
 import { EnvironmentManager } from './environment-manager.js';
@@ -266,18 +267,19 @@ app.use((err, req, res, next) => {
 // in-process without binding a port, registering exit-on-exception handlers,
 // or calling process.exit() during config validation.
 if (process.env.NODE_ENV !== 'test') {
-process.on('unhandledRejection', (reason) => {
-  unhandledRejectionCount++;
-  structuredLogger.error('unhandled_rejection', { reason: String(reason).slice(0, 500) });
-  audit({ event: 'process.unhandled_rejection', actor: 'system', reason: String(reason).slice(0, 200) });
+// Handlers live in crash.js so the crash path can be tested with a failing
+// audit sink — the exact condition that made a crash report the wrong cause
+// (HLCE-312). Everything they touch is injected here.
+const crashHandlers = createCrashHandlers({
+  logger: structuredLogger,
+  audit,
+  exit: (code) => process.exit(code),
+  onUncaught: () => { uncaughtExceptionCount++; },
+  onUnhandled: () => { unhandledRejectionCount++; },
 });
 
-process.on('uncaughtException', (err) => {
-  uncaughtExceptionCount++;
-  structuredLogger.error('uncaught_exception', { message: err.message?.slice(0, 500) });
-  audit({ event: 'process.uncaught_exception', actor: 'system', message: err.message?.slice(0, 200) });
-  setTimeout(() => process.exit(1), 100);
-});
+process.on('unhandledRejection', crashHandlers.handleUnhandledRejection);
+process.on('uncaughtException', crashHandlers.handleUncaughtException);
 
 process.on('SIGTERM', () => { logger.info('SIGTERM received'); dockerManager.destroy(); process.exit(0); });
 process.on('SIGINT', () => { logger.info('SIGINT received'); dockerManager.destroy(); process.exit(0); });


### PR DESCRIPTION
The uncaught-exception handler destroyed the evidence of the crash it was meant to record.

## The bug

```js
process.on('uncaughtException', (err) => {
  structuredLogger.error('uncaught_exception', { message: err.message?.slice(0, 500) });
  audit({ event: 'process.uncaught_exception', actor: 'system', message: ... });  // no `result`
  setTimeout(() => process.exit(1), 100);
});
```

`result` is `NOT NULL`. The insert threw, and a throw inside an `uncaughtException` handler is fatal — so the SqliteError became the crash. During HLCE-311 a plain EACCES on a fresh volume presented as a database constraint violation and sent the diagnosis at the database.

## Reproduced, before and after

Real handlers, real `audit()`, real logger, audit sink broken, then a genuine EACCES thrown.

**Before** — exit code **7**, and the fatal error is the wrong one:
```
{"level":"error","message":"uncaught_exception EACCES: permission denied, open '/app/server/activity-data/...'"}   <- no stack

SqliteError: no such table: audit_events
    at audit (server/audit.js:134:19)
    at process.handleUncaughtException
    at process._fatalException
```
Note the exit code: the secondary exception killed the process before the intended `exit(1)` was ever reached. The handler did not even fail the way it thought it did.

**After** — exit code **1**, cause first, with its stack:
```
{"level":"error","message":"uncaught_exception EACCES: permission denied, open '/app/server/activity-data/...',
 "stack":"Error: EACCES: permission denied...\n    at Timeout._onTimeout..."}
{"level":"error","message":"audit_write_failed_during_crash no such table: audit_events", "stack":"SqliteError..."}
```
The audit failure is still reported — clearly labelled, and additive rather than a replacement.

## What changed

- Report the original error, with its stack, first and unconditionally. Everything after is best-effort and individually guarded.
- `result: 'error'` supplied, so the insert does not fail in the first place.
- `unhandledRejection` had the identical missing-`result` defect (AC5) and is fixed with it. Those two were the only `audit()` callers in `server/` missing `result`.
- Crash detail moves into `meta`, which `audit()` actually persists. The old top-level `message`/`reason` keys were not columns and were silently discarded, so the reason never reached the row at all.
- A `console.error` floor if the structured logger itself throws — the incident was a filesystem error and winston writes to that same filesystem.
- Handlers move to `server/crash.js` with dependencies injected. In `index.js` they were registered inside `if (process.env.NODE_ENV !== 'test')`, so no test could reach them. That is why a crash-only bug shipped.

## Evidence

- 9 new tests drive the crash path with a sink that throws. Restoring the old ordering fails 5 of them, including the real-schema one, with the exact production error: `SqliteError: NOT NULL constraint failed: audit_events.result`.
- Full suite: 938 passed / 63 files. Coverage 84.65 lines / 83.91 stmts / 84.32 funcs / 76.43 branches, above the 83/82/83/75 gate.

Closes HLCE-312.