### PR TITLE
HLCE-323: create the major-update label instead of assuming it exists

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,6 +32,8 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
+  # Labels live on the issues API — without this, labelling a major fails.
+  issues: write
 
 jobs:
   automerge:
@@ -55,8 +57,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPS: ${{ steps.meta.outputs.dependency-names }}
         run: |
-          gh pr edit "$PR_URL" --add-label "major-update"
-          gh pr comment "$PR_URL" --body "Major version bump (\`${DEPS}\`) — left open on purpose. Routine patch and minor updates merge themselves; majors can change behaviour, so this one wants a person. Nothing is blocking: review and merge when you feel like it."
+          set -uo pipefail
+          # The label has to exist before it can be applied. The first real major
+          # to arrive found it missing, `gh pr edit` exited 1, and `bash -e` killed
+          # the step before it could leave its comment — so the PR was held
+          # correctly but silently. Create it idempotently instead of assuming.
+          gh label create major-update \
+            --color D93F0B \
+            --description "Major version bump — held for a human, never auto-merged" \
+            --force >/dev/null 2>&1 || echo "label already present"
+
+          # Comment once, not on every push to the branch.
+          if gh pr view "$PR_URL" --json labels --jq '.labels[].name' | grep -qx "major-update"; then
+            echo "Already held: ${DEPS}"
+            exit 0
+          fi
+
+          gh pr edit "$PR_URL" --add-label "major-update" || echo "could not label, continuing"
+          gh pr comment "$PR_URL" --body "Major version bump (\`${DEPS}\`) — left open on purpose. Routine patch and minor updates merge themselves; majors can change behaviour, so this one wants a person. Nothing is blocking: review and merge whenever suits."
           echo "Major update held: ${DEPS}"
 
       - name: Approve


### PR DESCRIPTION
Follow-up to #474, found by letting a real major bump (#470) run through the automation.

The hold path **worked** — nothing was approved and nothing merged — but it failed *silently*: `major-update` did not exist as a repo label, `gh pr edit --add-label` exited 1, and `bash -e` killed the step before it could post the comment explaining why the PR was being held.

```
DEPS: better-sqlite3-multiple-ciphers
'major-update' not found
##[error]Process completed with exit code 1
```

Fixes:
- create the label idempotently (`gh label create --force`) so this never depends on hand-configured repo state
- add `issues: write` — labels live on the issues API
- comment **once**, not on every push to the branch
- a labelling failure no longer swallows the comment

Worth noting it failed *safe*, not open: the major stayed unapproved and unmerged throughout.