### PR TITLE
HLCE-315: let the server say it is a demo instead of guessing from the URL

### DIFF
--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { isDemoMode } from '../demo-mode.js';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -12,6 +13,11 @@ export default function healthRoutes({ requireAuth, requireRole, sendError, dock
       ok: true,
       ts: Math.floor(Date.now() / 1000),
       state: 'ready',
+      // Whether this instance is the public demo. The frontend used to infer
+      // this from window.location.hostname, which silently stopped being true
+      // when the demo moved hosts (HLCE-315). The server is the only thing that
+      // actually knows, so it says so, on the one endpoint that needs no auth.
+      demo: isDemoMode(),
       process: {
         uptime_seconds: Math.floor(process.uptime()),
         ...counters,

--- a/server/routes/health.routes.test.js
+++ b/server/routes/health.routes.test.js
@@ -125,6 +125,46 @@ describe('AC2 — GET /health (liveness, no auth)', () => {
   });
 });
 
+// HLCE-315: the frontend decides whether it may show seeded demo containers
+// from this flag. It previously guessed from window.location.hostname and got
+// it wrong for the demo's own hostname, silently, for the whole life of the
+// demo. The server is the only party that actually knows.
+describe('GET /health — demo flag (HLCE-315)', () => {
+  afterEach(() => { delete process.env.DEMO_MODE; });
+
+  it('reports demo:false on a normal install', async () => {
+    const { app } = buildApp();
+    const res = await request(app).get('/health');
+    expect(res.body.demo).toBe(false);
+  });
+
+  it('reports demo:true when DEMO_MODE is set', async () => {
+    process.env.DEMO_MODE = 'true';
+    const { app } = buildApp();
+    const res = await request(app).get('/health');
+    expect(res.body.demo).toBe(true);
+  });
+
+  it('is a real boolean, never a string, and needs no auth', async () => {
+    // The frontend compares with === true, so a truthy string would read as
+    // not-a-demo and reintroduce the empty dashboard.
+    process.env.DEMO_MODE = '1';
+    const { app } = buildApp();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.demo).toBe(true);
+    expect(typeof res.body.demo).toBe('boolean');
+  });
+
+  it('stays false for values that do not explicitly enable demo mode', async () => {
+    for (const v of ['false', '0', 'yes', '']) {
+      process.env.DEMO_MODE = v;
+      const { app } = buildApp();
+      expect((await request(app).get('/health')).body.demo).toBe(false);
+    }
+  });
+});
+
 describe('AC2 — GET /health/detail (admin-only aggregate)', () => {
   it('rejects an unauthenticated request with 401 (real requireAuth)', async () => {
     const { app } = buildApp();

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -168,36 +168,72 @@ describe('apiFetch — 401 refresh interceptor', () => {
   });
 });
 
-describe('getContainers — demo fallback', () => {
-  // jsdom serves pages from http://localhost/ by default, so
-  // isDemoEnvironment() is already true (hostname === 'localhost').
+// HLCE-315. Whether the seeded container list may be substituted is decided by
+// the SERVER (`demo: true` on /health, set from DEMO_MODE), not by sniffing
+// window.location.hostname. The old predicate matched `dev.`/`staging.`/
+// `localhost` and never `demo.`/`ce-demo.`, so the live demo — the hostname
+// that actually mattered — always came back false and rendered empty.
+function healthResponse(demo: boolean) {
+  return mockResponse(200, { ok: true, state: 'ready', demo });
+}
 
-  it('returns the seeded demo containers when the fetch rejects (backend down)', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('network down'));
-    const { getContainers } = await importApi();
-
-    const data = await getContainers();
-
-    expect(Array.isArray(data.containers)).toBe(true);
-    expect(data.containers.length).toBeGreaterThan(0);
-    // shape of a seeded container
-    const names = data.containers.map((c: { Names: string[] }) => c.Names[0]);
-    expect(names).toContain('/plex');
-    const plex = data.containers.find((c: { Names: string[] }) => c.Names[0] === '/plex');
-    expect(plex).toMatchObject({ Id: expect.any(String), State: 'running' });
-  });
-
-  it('returns demo containers when the backend responds with an empty list', async () => {
-    fetchMock.mockResolvedValueOnce(mockResponse(200, { containers: [] }));
+describe('getContainers — demo fallback (HLCE-315)', () => {
+  it('substitutes the seeded containers when the server says it is a demo and the list is empty', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(200, { containers: [] }))
+      .mockResolvedValueOnce(healthResponse(true));
     const { getContainers } = await importApi();
 
     const data = await getContainers();
 
     expect(data.containers.length).toBeGreaterThan(0);
     expect(data.containers.map((c: { Names: string[] }) => c.Names[0])).toContain('/sonarr');
+    // The decision came from /health, not from the URL.
+    expect(fetchMock.mock.calls[1][0]).toContain('/health');
   });
 
-  it('returns the backend list unchanged when it has real containers', async () => {
+  it('substitutes the seeded containers when the request fails on a demo (backend down)', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(healthResponse(true));
+    const { getContainers } = await importApi();
+
+    const data = await getContainers();
+
+    const names = data.containers.map((c: { Names: string[] }) => c.Names[0]);
+    expect(names).toContain('/plex');
+    const plex = data.containers.find((c: { Names: string[] }) => c.Names[0] === '/plex');
+    expect(plex).toMatchObject({ Id: expect.any(String), State: 'running' });
+  });
+
+  it('never fabricates containers on a real install with an empty list', async () => {
+    // The inverse of the reported bug, and a real defect of the old predicate:
+    // any install reached at localhost — every developer, and plenty of real
+    // self-hosted ones — had eight fake containers injected the moment Docker
+    // reported none. jsdom serves from http://localhost/, so the old hostname
+    // check would return true here.
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(200, { containers: [] }))
+      .mockResolvedValueOnce(healthResponse(false));
+    const { getContainers } = await importApi();
+
+    const data = await getContainers();
+
+    expect(data.containers).toEqual([]);
+  });
+
+  it('returns an empty list, not seed data, when /health cannot be reached', async () => {
+    // Fail closed: showing a real deployment invented containers is worse than
+    // showing the demo none.
+    fetchMock
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockRejectedValueOnce(new Error('network down'));
+    const { getContainers } = await importApi();
+
+    expect((await getContainers()).containers).toEqual([]);
+  });
+
+  it('returns the backend list unchanged when it has real containers, without asking /health', async () => {
     const real = [{ Id: 'real-1', Names: ['/whoami'], State: 'running' }];
     fetchMock.mockResolvedValueOnce(mockResponse(200, { containers: real }));
     const { getContainers } = await importApi();
@@ -205,6 +241,33 @@ describe('getContainers — demo fallback', () => {
     const data = await getContainers();
 
     expect(data.containers).toEqual(real);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks the server only once per page load and shares the answer', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(200, { containers: [] }))
+      .mockResolvedValueOnce(healthResponse(true))
+      .mockResolvedValueOnce(mockResponse(200, { containers: [] }));
+    const { getContainers } = await importApi();
+
+    await getContainers();
+    await getContainers();
+
+    const healthCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes('/health'));
+    expect(healthCalls).toHaveLength(1);
+  });
+
+  it('treats a non-ok or non-boolean demo flag as not-a-demo', async () => {
+    for (const health of [mockResponse(500, {}), mockResponse(200, { demo: 'yes' }), mockResponse(200, {})]) {
+      vi.resetModules();
+      fetchMock.mockReset();
+      fetchMock
+        .mockResolvedValueOnce(mockResponse(200, { containers: [] }))
+        .mockResolvedValueOnce(health);
+      const { getContainers } = await importApi();
+      expect((await getContainers()).containers).toEqual([]);
+    }
   });
 
   it('requests the stats variant of the endpoint when includeStats is true', async () => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -145,23 +145,51 @@ export async function getContainers(includeStats = false) {
     const response = await apiFetch(path);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const data = await response.json();
-    if ((!data.containers || data.containers.length === 0) && isDemoEnvironment()) {
+    if ((!data.containers || data.containers.length === 0) && await isDemoInstance()) {
       return { ...data, containers: DEMO_CONTAINERS };
     }
     return data;
   } catch {
-    if (isDemoEnvironment()) {
+    if (await isDemoInstance()) {
       return { containers: DEMO_CONTAINERS };
     }
     return { containers: [] };
   }
 }
 
-function isDemoEnvironment(): boolean {
-  const host = window.location.hostname;
-  return host.includes('dev.') || host.includes('ce-dev.') ||
-         host.includes('staging.') || host.includes('ce-staging.') ||
-         host === 'localhost' || host === '127.0.0.1';
+// Is this instance the public demo, and therefore allowed to substitute the
+// seeded container list when it has none of its own?
+//
+// This used to guess from window.location.hostname, matching `dev.`, `staging.`
+// and `localhost`. Guessing was the bug (HLCE-315): the list never included
+// `demo.` or `ce-demo.`, so the actual demo — the first thing a prospective
+// user sees, linked straight from the Unraid Community Apps listing — rendered
+// an empty dashboard. Nothing failed loudly; the predicate simply returned
+// false forever, and it would have broken again the next time the demo moved.
+//
+// The server sets DEMO_MODE and is the only party that actually knows, so ask
+// it. That also fixes the inverse defect the hostname check had: a real install
+// reached at `localhost` — which is most of them, and every developer — got
+// eight fake containers injected the moment its own list was empty. Seed data
+// now requires a server that explicitly declares itself a demo.
+//
+// Cached as a promise: one answer per page load, and concurrent callers share
+// the same in-flight request rather than each firing their own.
+let demoInstance: Promise<boolean> | null = null;
+
+async function isDemoInstance(): Promise<boolean> {
+  demoInstance ??= (async () => {
+    try {
+      const response = await apiFetchRaw('/health');
+      if (!response.ok) return false;
+      return (await response.json())?.demo === true;
+    } catch {
+      // Unreachable or unparseable: assume a real install. Showing a real
+      // deployment fabricated containers is worse than showing the demo none.
+      return false;
+    }
+  })();
+  return demoInstance;
 }
 
 export async function getContainerStats(containerId: string) {


### PR DESCRIPTION
`isDemoEnvironment()` tested `dev.`, `ce-dev.`, `staging.`, `ce-staging.`, `localhost`, `127.0.0.1` — every hostname except the two the demo is actually served on. So the seeded container list never rendered on the demo, and the first thing a prospective user saw, linked straight from the Unraid Community Apps listing, was an empty dashboard.

Nothing failed loudly. The predicate just returned `false` forever.

## The call I made

**The demo shows the seeded containers, keyed on an explicit server signal.**

The hostname sniffing is the part that was actually broken — it was guessing at something it could not observe, and it would have broken again the next time the demo moved hosts. The backend already knows: `DEMO_MODE`, added with the demo guard in HLCE-321, and confirmed live on demo.homelabarr.com (`/api/auth/forgot-password` returns `403 code:demo_mode`). So `/health` now reports `demo: true|false` and the frontend asks.

Seeded over an honest empty state because the seed list already exists for exactly this case, empty-state UI is out of scope on the ticket, and an empty grid under a dashboard promising "manage your home lab Docker containers" is a bad first impression in the one place it matters most.

## The bug in the other direction

The old predicate matched `localhost`, so **any real install reached at localhost — every developer, and plenty of real self-hosted ones — had eight fake containers injected the moment Docker legitimately reported none.** Seed data now requires a server that explicitly declares itself a demo, and an unreachable `/health` fails closed to the real (empty) list. Showing a real deployment invented containers is worse than showing the demo none.

## Verified against a real server

```
DEMO_MODE unset -> demo=false
DEMO_MODE=true  -> demo=true
DEMO_MODE=1     -> demo=true
DEMO_MODE=false -> demo=false
```
Four separate boots of the real backend, distinct PIDs (a first attempt reported a stale answer because the process had not actually restarted — the uptime counter gave it away).

## Also

- `staging.` / `ce-staging.` dropped, dead since HLCE-314 (AC4).
- The answer is cached per page load, so concurrent callers share one request.
- 13 tests: server flag across `DEMO_MODE` values incl. the type (`=== true`, so a truthy string would silently reintroduce the empty dashboard), and the frontend across demo / real-install / unreachable-health / real-containers / caching.
- Full suite 937 passed / 62 files. Coverage 84.51 lines / 83.76 stmts / 84.21 funcs / 76.51 branches, above the 83/82/83/75 gate. `tsc --noEmit` and eslint clean.

Closes HLCE-315.