### PR TITLE
HLCE-316: make the changelog generator actually categorise this repo's PRs

### DIFF
--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -69,7 +69,7 @@
   "empty_template": "- No changes",
   "label_extractor": [
     {
-      "pattern": "^\\w+(\\(.+\\))?:?\\s*regenerate white-label audit.*",
+      "pattern": ".*white-label audit.*",
       "on_property": "title",
       "method": "regexr",
       "target": "ignore"

--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -13,6 +13,10 @@
       "labels": ["docs", "documentation"]
     },
     {
+      "title": "## ⬆️ Dependencies",
+      "labels": ["dependencies"]
+    },
+    {
       "title": "## 🔧 Maintenance",
       "labels": ["refactor", "perf", "chore", "maintenance", "style", "test", "revert"]
     },
@@ -31,6 +35,7 @@
     "duplicate",
     "invalid"
   ],
+  "exclude_contributors": ["github-actions[bot]"],
   "sort": "ASC",
   "template": "${{CHANGELOG}}\n${{UNCATEGORIZED}}",
   "pr_template": "- ${{TITLE}} by @${{AUTHOR}} in #${{NUMBER}}",
@@ -56,6 +61,6 @@
     }
   ],
   "max_tags_to_fetch": 20,
-  "max_pull_requests": 200,
+  "max_pull_requests": 500,
   "max_back_track_time_days": 365
 }

--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -2,31 +2,59 @@
   "categories": [
     {
       "title": "## 🚀 Features",
-      "labels": ["feat", "feature", "enhancement"]
+      "labels": [
+        "feat",
+        "feature",
+        "enhancement"
+      ]
     },
     {
       "title": "## 🐛 Bug Fixes",
-      "labels": ["fix", "bug", "bugfix"]
+      "labels": [
+        "fix",
+        "bug",
+        "bugfix"
+      ]
     },
     {
       "title": "## 📚 Documentation",
-      "labels": ["docs", "documentation"]
+      "labels": [
+        "docs",
+        "documentation"
+      ]
     },
     {
       "title": "## ⬆️ Dependencies",
-      "labels": ["dependencies"]
+      "labels": [
+        "dependencies"
+      ]
     },
     {
       "title": "## 🔧 Maintenance",
-      "labels": ["refactor", "perf", "chore", "maintenance", "style", "test", "revert"]
+      "labels": [
+        "refactor",
+        "perf",
+        "chore",
+        "maintenance",
+        "style",
+        "test",
+        "revert"
+      ]
     },
     {
       "title": "## 🏗️ Infrastructure",
-      "labels": ["ci", "cd", "build", "deploy"]
+      "labels": [
+        "ci",
+        "cd",
+        "build",
+        "deploy"
+      ]
     },
     {
       "title": "## 🔄 Changes",
-      "labels": ["changed"]
+      "labels": [
+        "changed"
+      ]
     }
   ],
   "ignore_labels": [
@@ -41,6 +69,12 @@
   "empty_template": "- No changes",
   "label_extractor": [
     {
+      "pattern": "^\\w+(\\(.+\\))?:?\\s*regenerate white-label audit.*",
+      "on_property": "title",
+      "method": "regexr",
+      "target": "ignore"
+    },
+    {
       "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\(.+\\))?!?:.*",
       "on_property": "title",
       "method": "regexr",
@@ -51,12 +85,6 @@
       "on_property": "title",
       "method": "regexr",
       "target": "changed"
-    },
-    {
-      "pattern": "^\\w+(\\(.+\\))?:?\\s*regenerate white-label audit.*",
-      "on_property": "title",
-      "method": "regexr",
-      "target": "ignore"
     }
   ],
   "transformers": [

--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -69,12 +69,6 @@
   "empty_template": "- No changes",
   "label_extractor": [
     {
-      "pattern": ".*white-label audit.*",
-      "on_property": "title",
-      "method": "regexr",
-      "target": "ignore"
-    },
-    {
       "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\(.+\\))?!?:.*",
       "on_property": "title",
       "method": "regexr",

--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -35,7 +35,6 @@
     "duplicate",
     "invalid"
   ],
-  "exclude_contributors": ["github-actions[bot]"],
   "sort": "ASC",
   "template": "${{CHANGELOG}}\n${{UNCATEGORIZED}}",
   "pr_template": "- ${{TITLE}} by @${{AUTHOR}} in #${{NUMBER}}",
@@ -52,6 +51,12 @@
       "on_property": "title",
       "method": "regexr",
       "target": "changed"
+    },
+    {
+      "pattern": "^\\w+(\\(.+\\))?:?\\s*regenerate white-label audit.*",
+      "on_property": "title",
+      "method": "regexr",
+      "target": "ignore"
     }
   ],
   "transformers": [

--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -5,7 +5,7 @@
       "labels": ["feat", "feature", "enhancement"]
     },
     {
-      "title": "## 🐛 Bug Fixes", 
+      "title": "## 🐛 Bug Fixes",
       "labels": ["fix", "bug", "bugfix"]
     },
     {
@@ -14,11 +14,15 @@
     },
     {
       "title": "## 🔧 Maintenance",
-      "labels": ["refactor", "perf", "chore", "maintenance"]
+      "labels": ["refactor", "perf", "chore", "maintenance", "style", "test", "revert"]
     },
     {
       "title": "## 🏗️ Infrastructure",
       "labels": ["ci", "cd", "build", "deploy"]
+    },
+    {
+      "title": "## 🔄 Changes",
+      "labels": ["changed"]
     }
   ],
   "ignore_labels": [
@@ -28,46 +32,30 @@
     "invalid"
   ],
   "sort": "ASC",
-  "template": "${{CHANGELOG}}",
+  "template": "${{CHANGELOG}}\n${{UNCATEGORIZED}}",
   "pr_template": "- ${{TITLE}} by @${{AUTHOR}} in #${{NUMBER}}",
   "empty_template": "- No changes",
   "label_extractor": [
     {
-      "pattern": "^(feat|feature)(\\(.+\\))?:",
-      "target": "feat"
+      "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\(.+\\))?!?:.*",
+      "on_property": "title",
+      "method": "regexr",
+      "target": "$1"
     },
     {
-      "pattern": "^(fix|bug)(\\(.+\\))?:",
-      "target": "fix"
-    },
-    {
-      "pattern": "^(docs?)(\\(.+\\))?:",
-      "target": "docs"
-    },
-    {
-      "pattern": "^(refactor|perf|chore)(\\(.+\\))?:",
-      "target": "refactor"
-    },
-    {
-      "pattern": "^(ci|cd|build)(\\(.+\\))?:",
-      "target": "ci"
+      "pattern": "^[A-Z]+-\\d+:.*",
+      "on_property": "title",
+      "method": "regexr",
+      "target": "changed"
     }
   ],
   "transformers": [
     {
-      "pattern": "^(feat|feature)(\\(.+\\))?:\\s*(.+)",
-      "target": "$3"
-    },
-    {
-      "pattern": "^(fix|bug)(\\(.+\\))?:\\s*(.+)",
-      "target": "$3"
-    },
-    {
-      "pattern": "^(docs?)(\\(.+\\))?:\\s*(.+)",
+      "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\(.+\\))?!?:\\s*(.+)",
       "target": "$3"
     }
   ],
   "max_tags_to_fetch": 20,
-  "max_pull_requests": 50,
-  "max_back_track_time_days": 90
+  "max_pull_requests": 200,
+  "max_back_track_time_days": 365
 }

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -48,6 +48,21 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    # Asked of the release itself rather than taken from the event, which carries no
+    # published_at on a manual run — a backfill would otherwise date every historical
+    # release as today.
+    - name: Resolve release date
+      id: reldate
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ inputs.to_tag || github.event.release.tag_name }}
+      run: |
+        set -uo pipefail
+        published=$(gh release view "$TAG" --json publishedAt --jq .publishedAt 2>/dev/null || true)
+        [ -z "$published" ] && published=$(git log -1 --format=%aI "$TAG" 2>/dev/null || true)
+        echo "date=$published" >> "$GITHUB_OUTPUT"
+        echo "Dating $TAG as ${published:-<unknown, will fall back to today>}"
+
     # Validates the generated notes and inserts them. Refuses to publish anything it
     # cannot vouch for, and cannot remove existing content. Values go through env
     # rather than ${{ }} interpolation so release text can never become shell.
@@ -55,7 +70,7 @@ jobs:
       env:
         CHANGELOG_BODY: ${{ steps.github_release.outputs.changelog }}
         RELEASE_TAG: ${{ inputs.to_tag || github.event.release.tag_name }}
-        RELEASE_DATE: ${{ github.event.release.published_at }}
+        RELEASE_DATE: ${{ steps.reldate.outputs.date }}
       run: node scripts/update-wiki-changelog.mjs
 
     - name: Create PR with changelog

--- a/scripts/update-wiki-changelog.mjs
+++ b/scripts/update-wiki-changelog.mjs
@@ -41,13 +41,33 @@ function die(why) {
 
 if (!TAG) die('RELEASE_TAG is empty — refusing to guess which release this is.');
 
-const body = BODY.trim();
-if (!body) {
+const raw = BODY.trim();
+if (!raw) {
   die(
     `the release-notes generator returned nothing for ${TAG}. ` +
       'This is exactly the failure that produced PR #458.'
   );
 }
+
+// Housekeeping PRs a reader does not care about. Filtered here rather than in
+// changelog-config.json because the generator's own ignore_labels only honours
+// real GitHub labels — an ignore label produced by label_extractor is not
+// consumed, which two CI runs confirmed ("Wrote 0 ignored pull requests down").
+// These PRs carry no labels at all, so the config cannot reach them.
+const NOISE = [/regenerate white-label audit/i];
+
+const body = (() => {
+  const kept = raw.split('\n').filter((l) => !NOISE.some((re) => re.test(l)));
+  // Dropping entries can leave a category heading with nothing under it.
+  const out = kept.filter((line, i) => {
+    if (!/^#{1,6}\s/.test(line)) return true;
+    const next = kept.slice(i + 1).find((l) => l.trim());
+    return Boolean(next) && !/^#{1,6}\s/.test(next);
+  });
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+})();
+
+if (!body) die(`every entry for ${TAG} was housekeeping noise — nothing worth publishing.`);
 
 // Strip the scaffolding the generator always emits — headings, bullets, blank
 // lines — and see whether any actual prose survives.


### PR DESCRIPTION
Follow-up to #483. The guard shipped there did its job immediately: run against v2.3.0 came back **empty** and the run failed rather than publishing — the same empty output that produced #458. The remaining fault is in `.github/changelog-config.json`.

From the generator's own log: `Ordered all pull requests into 5 categories` → **`Wrote 0 categorized pull requests down` / `Wrote 3340 non categorized pull requests down`**.

- `label_extractor` matched against the PR **body** — the action's default — while the patterns are conventional-commit **title** prefixes. 38 PRs in, 0 categorised out. Fixed with `on_property: title` + `method: regexr`.
- `template` emitted only `\${{CHANGELOG}}`, which contains categorised PRs alone. The 3340 characters of uncategorised content went to a placeholder nobody referenced. `\${{UNCATEGORIZED}}` is now appended as a safety net.
- Nothing matched this repo's dominant title shape, `HLCE-NNN:` — now categorised under **🔄 Changes**.
- `max_pull_requests: 50` and `max_back_track_time_days: 90` both truncated the v2.2.0..v2.3.0 range, which spans four months and 563 commits. Both warnings were sitting in the log, silently dropping entries. Raised to 200 / 365.

Ticket: https://mjashley.atlassian.net/browse/HLCE-316