### PR TITLE
Sync docs to imogenlabs org + current app count

### DIFF
--- a/docs/governance/github-security-settings.md
+++ b/docs/governance/github-security-settings.md
@@ -1,6 +1,6 @@
 # GitHub Security Settings — Required Configuration
 
-These settings must be enabled at `Settings → Code security and analysis` for the `smashingtags/homelabarr-ce` repository.
+These settings must be enabled at `Settings → Code security and analysis` for the `imogenlabs/homelabarr-ce` repository.
 
 ## Required settings
 
@@ -24,8 +24,8 @@ These settings must be enabled at `Settings → Code security and analysis` for 
 The agent can check current state via the GitHub API:
 
 ```bash
-gh api repos/smashingtags/homelabarr-ce --jq '.security_and_analysis'
-gh api repos/smashingtags/homelabarr-ce/private-vulnerability-reporting
+gh api repos/imogenlabs/homelabarr-ce --jq '.security_and_analysis'
+gh api repos/imogenlabs/homelabarr-ce/private-vulnerability-reporting
 ```
 
 Enabling these settings requires repository admin access (owner-only).

--- a/wiki/docs/guides/history.md
+++ b/wiki/docs/guides/history.md
@@ -48,12 +48,12 @@ Sudobox was the right idea at the right time — but it never shipped. The commu
 
 HomelabARR CE is the GUI that actually shipped:
 
-- **A web GUI** — React-based dashboard with a 157+ app catalog. No more editing YAML files or running Ansible playbooks. Browse apps, click Deploy, watch it happen.
+- **A web GUI** — React-based dashboard with a 117+ app catalog. No more editing YAML files or running Ansible playbooks. Browse apps, click Deploy, watch it happen.
 - **A CLI menu system** — interactive terminal interface for users who prefer the command line.
 - **No plugin dependencies** — removed the `local-persist` volume plugin requirement. Everything works with standard Docker out of the box.
 - **Proper CI/CD** — GitHub Actions pipelines, automated Docker image builds, Dependabot updates, CodeQL security scanning.
 - **Comprehensive documentation** — full wiki with migration guides for every major platform (Saltbox, Cloudbox, PGBlitz, Dockserver).
-- **One-line install** — `sudo wget -qO- https://raw.githubusercontent.com/smashingtags/homelabarr-ce/main/install-remote.sh | sudo bash`
+- **One-line install** — `sudo wget -qO- https://raw.githubusercontent.com/imogenlabs/homelabarr-ce/main/install-remote.sh | sudo bash`
 
 CE is free, open source, and MIT licensed. It's the community edition — designed to be the easiest way to get a media server running. Built and maintained by one person from a server rack in Georgia.
 

--- a/wiki/docs/guides/white-label.md
+++ b/wiki/docs/guides/white-label.md
@@ -38,7 +38,7 @@ OLD_BRAND="HomelabARR"        # human-readable brand name
 NEW_NAME="myproject"          # your lowercase identifier
 NEW_BRAND="MyProject"         # your human-readable brand
 
-OLD_REPO="smashingtags/homelabarr-ce"
+OLD_REPO="imogenlabs/homelabarr-ce"
 NEW_REPO="yourorg/yourproject"
 
 OLD_DOMAIN="homelabarr.com"


### PR DESCRIPTION
## Summary
- wiki/docs/guides/history.md — the one-line install command example still pointed at the old `smashingtags` org; the app-catalog figure ("157+") was stale against the verified count used elsewhere in the repo (117, per README and HLCE-260's own README fix)
- wiki/docs/guides/white-label.md — `OLD_REPO` in the 5-minute white-label starter script was still `smashingtags/homelabarr-ce`, so running that script against the actual repo today would silently fail to find/replace any current-org references, leaving a forked README/docs pointing at the wrong upstream
- docs/governance/github-security-settings.md — the `gh api repos/...` example commands and prose referenced `smashingtags/homelabarr-ce`

All four changes verified before writing:
- `raw.githubusercontent.com/imogenlabs/homelabarr-ce/main/install-remote.sh` returns 200
- `gh api repos/imogenlabs/homelabarr-ce` returns the canonical repo
- App count 117 confirmed against README's own category table and disk contents (`apps/*` minus config-only YAMLs), matching CHANGELOG entry `HLCE-260: README — E2E lanes + app count 117`

## Out of scope (left as-is, deliberately)
- Historical narrative/attribution in history.md (contributor names, predecessor-project lineage) — white-label.md's own "Legal" section says to keep this as-is
- `docs/audit/*` — point-in-time security audit trail, not living docs
- `@smashingtags` as a GitHub *username* in CHANGELOG.md attribution, ISSUE_TEMPLATE assignee, `docs/ir/`, `docs/decisions/` — that account is still real and unchanged, only the *org* renamed
- `.github/workflows/docker-build-push.yml` Docker Hub namespace — its own comment says this intentionally stays `smashingtags` (separate personal Docker Hub account, not migrated)
- `apps/system/cf-companion.yml` / `traefik/templates/compose/docker-compose.yml` image refs — functional app-template code, out of the doc-sync brief's scope

## Test plan
- [x] Verified README.md's own install instructions (git clone + compose) already match the real install path — no change needed there
- [x] Verified `ghcr.io/imogenlabs/homelabarr-backend` pulls a manifest (200) — confirms the org-migrated registry path is live
- [x] Verified README's security-audit claims ("22-round", "241+ findings", "11 playbooks") against `docs/audit/README.md` and `docs/ir/playbooks/` — all accurate, no change
- [x] Verified README's "10 route modules" and port numbers (8084/8092) against `server/routes/` and `homelabarr.yml` — accurate, no change