### PR TITLE
HLCE-328: restore container log reads through the socket proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Three containers. That's the whole stack.
 |---------|-------------|------|
 | **Frontend** | React dashboard served by nginx. What you see in your browser. | 8084 |
 | **Backend** | Reads app templates, talks to Docker via socket proxy, handles auth. Node.js + Express. | 8092 |
-| **Socket Proxy** | Mediates Docker API access. `EXEC=0`, `BUILD=0`, `cap_drop: ALL`, read-only. | internal |
+| **Socket Proxy** | Mediates Docker API access. `EXEC=0`, `BUILD=0`, `cap_drop: ALL`, read-only. Start/stop/restart and log reads are each an explicit grant. | internal |
 
 <p align="center">
     <img src="wiki/docs/img/diagrams/system-architecture.png" alt="System Architecture" width="700">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -160,6 +160,7 @@ docker buildx imagetools inspect \
 - `DEFAULT_ADMIN_PASSWORD` set explicitly OR removed after first-boot bootstrap
 - `CORS_ORIGIN` pinned to the exact public origin (no wildcards)
 - Docker socket proxy (`socket-proxy` service) present with `EXEC=0, BUILD=0`
+- Socket proxy grants are the four the UI needs and no more: `ALLOW_START`, `ALLOW_STOP`, `ALLOW_RESTARTS`, `ALLOW_LOGS`. Leave `ALLOW_TOP`, `ALLOW_ARCHIVE`, `ALLOW_CHANGE` and `ALLOW_EXPORT` unset — the app never calls them
 - `docker inspect homelabarr-backend` shows `ReadonlyRootfs: true` and `CapDrop: [ALL]`
 - Images pinned to a tag AND sha256 digest in your compose file
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -20,7 +20,11 @@ services:
   # Docker socket proxy — allow-listed API only (no EXEC/BUILD), same posture as
   # production, but with START/STOP/RESTART enabled so the lifecycle journey works.
   socket-proxy:
-    image: lscr.io/linuxserver/socket-proxy:latest
+    # Pinned, deliberately. A floating :latest here let an upstream socket-proxy
+    # release turn this required check red on main for six days and block every
+    # open PR. Dependabot bumps the tag+digest, so the same upstream change now
+    # arrives as a PR that goes red instead of poisoning main.
+    image: lscr.io/linuxserver/socket-proxy:3.4.4@sha256:c0e905167a19a756f47e7fcf724ac08e47a883238ef2e1dfb1bd62e94d481ce5
     container_name: hlce-e2e-socket-proxy
     restart: unless-stopped
     environment:
@@ -37,6 +41,9 @@ services:
       - ALLOW_START=1
       - ALLOW_STOP=1
       - ALLOW_RESTARTS=1
+      # Container log reads are their own opt-in permission and default to off;
+      # without this the log-viewer journey sees a 403 and an empty dialog.
+      - ALLOW_LOGS=1
       - BUILD=0
       - COMMIT=0
       - EXEC=0

--- a/docs/threat-model/02-trust-boundaries.md
+++ b/docs/threat-model/02-trust-boundaries.md
@@ -6,7 +6,7 @@
 
 3. **nginx → backend container** — HTTP over Docker bridge network. Auth: none (network isolation is the boundary). Controls: R4 internal network (`homelabarr-internal`), R9.6 route gating.
 
-4. **Backend → socket-proxy → Docker daemon** — HTTP/TCP over internal Docker network. Auth: none (endpoint allowlist on proxy). Controls: R4 socket proxy with EXEC=0/BUILD=0, R4 cap-drop ALL on backend.
+4. **Backend → socket-proxy → Docker daemon** — HTTP/TCP over internal Docker network. Auth: none (endpoint allowlist on proxy). Controls: R4 socket proxy with EXEC=0/BUILD=0 and a per-operation allowlist (`ALLOW_START`/`ALLOW_STOP`/`ALLOW_RESTARTS`/`ALLOW_LOGS` only), R4 cap-drop ALL on backend.
 
 5. **Backend → data volume (SQLCipher DB)** — Filesystem read/write. Auth: SQLCipher key from Docker secrets. Controls: R7 encryption at rest, R6 hash-chained audit log.
 

--- a/homelabarr.yml
+++ b/homelabarr.yml
@@ -33,7 +33,10 @@ services:
 
   # Docker socket proxy — allow-listed API access only, no EXEC/BUILD
   socket-proxy:
-    image: lscr.io/linuxserver/socket-proxy:latest@sha256:a1740f01925d07c4ed6e73ea21ec798cff28e0a811b3c1672617b95eee76d79c
+    # Pinned to a VERSION tag, not :latest, so Dependabot can compare releases and
+    # propose the bump. A `:latest@sha256:` pin is frozen forever — Dependabot has
+    # no version to compare, which is how this sat on a May 2026 image for months.
+    image: lscr.io/linuxserver/socket-proxy:3.4.4@sha256:c0e905167a19a756f47e7fcf724ac08e47a883238ef2e1dfb1bd62e94d481ce5
     container_name: homelabarr-socket-proxy
     restart: unless-stopped
     environment:
@@ -50,6 +53,11 @@ services:
       - ALLOW_START=1
       - ALLOW_STOP=1
       - ALLOW_RESTARTS=1
+      # Required for the View Logs action. socket-proxy split container log
+      # reads out of CONTAINERS into their own opt-in permission, defaulting
+      # to off; without this GET /containers/{id}/logs returns 403 and the log
+      # viewer opens empty. Grants read-only access to that one path.
+      - ALLOW_LOGS=1
       - BUILD=0
       - COMMIT=0
       - CONFIGS=0

--- a/wiki/docs/guides/faq.md
+++ b/wiki/docs/guides/faq.md
@@ -85,6 +85,18 @@ export DOCKER_GID=YOUR_NUMBER
 docker compose -f homelabarr.yml up -d
 ```
 
+### "View Logs" opens an empty dialog
+
+Your socket proxy is denying the log read. Recent socket-proxy releases moved container log reads out of the general `CONTAINERS` permission into their own opt-in flag, which defaults to off, so `GET /containers/{id}/logs` comes back `403 Forbidden` and the viewer has nothing to show.
+
+Add `ALLOW_LOGS=1` to the `socket-proxy` service's `environment:` block and recreate it:
+
+```bash
+docker compose -f homelabarr.yml up -d --force-recreate socket-proxy
+```
+
+The shipped `homelabarr.yml` already sets it. This affects you only if you wrote your own compose file or run your own proxy.
+
 ### Running in a Proxmox LXC container
 
 Docker inside LXC needs AppArmor disabled at the Proxmox host level:

--- a/wiki/docs/guides/security.md
+++ b/wiki/docs/guides/security.md
@@ -13,7 +13,7 @@ HomelabARR CE ships with a production-grade security envelope by default. This p
 - **CSRF protection:** double-submit cookie pattern with constant-time compare.
 - **API keys:** HMAC-SHA256 hashed before storage. `hlr_` prefix. Never stored in plaintext.
 - **Audit log:** hash-chained tamper-evident log with daily rotation. Every auth event, container action, and admin operation is recorded.
-- **Docker socket proxy:** backend never touches the Docker socket directly. A linuxserver socket-proxy sidecar with endpoint allowlist (EXEC=0, BUILD=0) mediates all Docker API access.
+- **Docker socket proxy:** backend never touches the Docker socket directly. A linuxserver socket-proxy sidecar with an endpoint allowlist mediates all Docker API access. `EXEC=0` and `BUILD=0` deny arbitrary command execution and image builds; `ALLOW_START`, `ALLOW_STOP`, `ALLOW_RESTARTS` and `ALLOW_LOGS` grant exactly the four container operations the dashboard offers. `ALLOW_LOGS` is read-only and covers only `GET /containers/{id}/logs` — without it the View Logs dialog opens empty.
 - **Container hardening:** `cap_drop: ALL`, `read_only: true`, `no-new-privileges`, memory/PID limits, AppArmor profile.
 - **Encryption at rest:** SQLCipher AES-256 on all databases. Key rotation scripts included.
 


### PR DESCRIPTION
Fixes the root cause behind every BLOCKED PR in the queue, and a real product regression behind it.

## What was wrong

`lscr.io/linuxserver/socket-proxy` split container log reads out of the `CONTAINERS` permission into a new opt-in `ALLOW_LOGS` that defaults to **off**. Since that release:

- `GET /containers/{id}/logs` returns **403**, so the app's **View Logs** dialog opens empty for anyone running a current proxy image.
- The **E2E (seeded target)** check — a required status check — went red on `main` on 2026-08-23 and has blocked all 10 open PRs for six days.

The proxy's own `/templates/haproxy.cfg` confirms it:

```
acl allow_logs env(ALLOW_LOGS) -m bool
http-request deny if { path,url_dec -m reg -i ^(/v[\d\.]+)?(/libpod)?/(containers|pods)/[a-zA-Z0-9_.-]+/(logs) } !allow_logs
```

## What this changes

**`ALLOW_LOGS=1`** in `homelabarr.yml` and `docker-compose.e2e.yml`. It is read-only and grants exactly that one path. `ALLOW_TOP`, `ALLOW_ARCHIVE`, `ALLOW_CHANGE` and `ALLOW_EXPORT` stay unset — the app never calls them.

**Both images move to a pinned version tag.** Two different bugs, one fix:

- `docker-compose.e2e.yml` tracked a bare `:latest`, which is how an upstream push poisoned `main` — the same shape as the `npm@latest` float in HLCE-306.
- `homelabarr.yml` pinned `:latest@sha256:...`, which gives Dependabot no version to compare, so it **never proposed a bump**. The shipped stack was sitting on a **2026-05-14** image (3.2.19-r0-ls82), three and a half months and twelve releases stale.

A real tag plus digest means the next upstream change arrives as a Dependabot PR that goes red, rather than silently breaking `main`.

**Docs** updated where the proxy posture is described: README service table, SECURITY.md production checklist, the wiki security guide, the threat model's trust boundary 4, and a new FAQ entry for the symptom users will actually hit ("View Logs opens an empty dialog").

## Verification

Reproduced first, then fixed. With the cached 2026-08-05 image the suite passed; after `docker pull` (3.4.4-r0-ls94) it reproduced the exact CI failure.

```
AC2  socket-proxy GET /containers/{id}/logs => HTTP 200   (was 403)
AC1  playwright --project=seeded            => 18 passed
     tsc --project tsconfig.app.json --noEmit => clean
     eslint . --quiet                         => clean
```

Note: 13 `server/ratelimit.test.js` / `auth-admin` / `demo-mode` tests fail on this machine, but they fail identically on `main` and `unit-tests.yml` is green on `main` — local Node 25 vs the pinned Node 24, not this change.

https://claude.ai/code/session_01GxerHoz2hfRhxRPUosdZjN